### PR TITLE
doc: Small typo

### DIFF
--- a/src/docs/guide-numerical-evaluations.md
+++ b/src/docs/guide-numerical-evaluations.md
@@ -33,7 +33,7 @@ console.log(ce.parse('\\sqrt{5} + 7^3').numericValue?.latex);
 console.log(ce.parse('\\sqrt{x} + 7^3').N().latex);
 // ➔ "\sqrt{x} + 343"
 
-console.log(ce.parse('\\sqrt{5} + 7^3').numericValue?.latex);
+console.log(ce.parse('\\sqrt{x} + 7^3').numericValue?.latex);
 // ➔ undefined
 ```
 


### PR DESCRIPTION
since `ce.parse('\\sqrt{5} + 7^3').numericValue?.latex` was already shown having a value, I believe this is what was meant