### PR TITLE
fix: latex-syntax logic definition fixed \\operatorname{or} 'And' to …

### DIFF
--- a/src/compute-engine/latex-syntax/dictionary/definitions-logic.ts
+++ b/src/compute-engine/latex-syntax/dictionary/definitions-logic.ts
@@ -81,7 +81,7 @@ export const DEFINITIONS_LOGIC: LatexDictionary = [
   {
     kind: 'infix',
     latexTrigger: '\\operatorname{or}',
-    parse: 'And',
+    parse: 'Or',
     precedence: 310,
   },
 


### PR DESCRIPTION
https://github.com/cortex-js/compute-engine/issues/73#issuecomment-1729769722

Here is the PR. Changed one word. Hope it helps.