### PR TITLE
NetxJS Webpack bundling fails in 0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,14 @@
   "files": [
     "/dist"
   ],
+  "exports": {
+    ".": {
+        "types": "./dist/types/compute-engine.d.ts",
+        "require": "./dist/compute-engine.min.js",
+        "import": "./dist/compute-engine.min.esm.js",
+        "default": "./dist/compute-engine.min.js"
+    }
+  },
   "main": "./dist/compute-engine.min.js",
   "module": "./dist/compute-engine.min.esm.js",
   "types": "./dist/types/compute-engine.d.ts",
@@ -76,6 +84,5 @@
   "dependencies": {
     "complex.js": "^2.1.1",
     "decimal.js": "^10.4.3"
-  },
-  "type": "module"
+  }
 }


### PR DESCRIPTION
This is a possible fix for #123.

The field `"type": "module"` defines all .js files in that package scope as ES modules, which breaks webpack bundling, if commonjs files are imported. This was introduced in `0.17.0` with #122.

The approach taken in this PR to add support for a hybrid cjs and esm package is through `exports` in `packages.json`, see https://webpack.js.org/guides/package-exports/#conditions, and should work with vite through rollup.

This has been tested on NextJS `13.5.4` and Webpack 5 and bundles correctly.


