### PR TITLE
Fix x/2/y.  It was yielding (xy)/2 rather than x/(2y).

### DIFF
--- a/src/compute-engine/library/arithmetic-divide.ts
+++ b/src/compute-engine/library/arithmetic-divide.ts
@@ -53,7 +53,7 @@ export function canonicalDivide(
     );
   }
   if (op1.head === 'Divide')
-    return canonicalDivide(ce, ce.mul(op1.op1, op2), op1.op2);
+    return canonicalDivide(ce, op1.op1, ce.mul(op1.op2, op2));
   if (op2.head === 'Divide')
     return canonicalDivide(ce, ce.mul(op1, op2.op2), op2.op1);
 


### PR DESCRIPTION
This patch fixes a problem in symbolic evaluation of the division of a fraction by something else.

### How to reproduce

    const ce = new ComputeEngine();
    var expr = ce.parse("(x/2)/y");
    console.log(expr.json);

### Actual behavior

    [ 'Divide', [ 'Multiply', 'x', 'y' ], 2 ]

### Expected behavior

    [ 'Divide', 'x', [ 'Multiply', 2, 'y' ] ]

#### Environment

compute-engine 0.23.1

I have not tried previous versions.

Cheers!