### PR TITLE
MathJSON Or operator was evaluating to True given all False args

### DIFF
--- a/src/compute-engine/library/logic.ts
+++ b/src/compute-engine/library/logic.ts
@@ -163,7 +163,7 @@ function processOr(
       if (!duplicate) ops.push(arg);
     }
   }
-  if (ops.length === 0) return ce.True;
+  if (ops.length === 0) return ce.False;
   if (ops.length === 1) return ops[0];
   return ce._fn('Or', ops);
 }


### PR DESCRIPTION
Here's a patch that makes ["Or","False","False"] yield "False" rather than "True".

Thanks!