### PR TITLE
When evaluating special inverse trig values, use isEqual rather than isSame

### DIFF
--- a/src/compute-engine/library/trigonometry.ts
+++ b/src/compute-engine/library/trigonometry.ts
@@ -827,7 +827,7 @@ function constructibleValuesInverse(
   }
 
   for (const [[match_arg, match_arg_N], [n,d]] of specialInverseValues) {
-    if (ce.chop(x_N - match_arg_N) === 0 && match_arg.isSame(x)) {
+    if (ce.chop(x_N - match_arg_N) === 0 && match_arg.isEqual(x)) {
       // there is an implicit Pi in the numerator
       let theta = ce.box(['Divide',['Multiply',n,'Pi'],d]);
       if( quadrant == -1 ) {


### PR DESCRIPTION
Apparently, my fingers typed isSame() when I was thinking isEqual().

By the way: the comparison is redundant, since the argument to the inverse trig function is compared numerically to the key value and only if that approximately matches does it compare using isEqual(), which may just boil down to the same numerical test.  However, I thought it might be best to call isEqual() to express the formal intent to do an exact comparison here.  If the philosophy is to allow actual floating point input to match exact values in cases like this, then I think the isEqual() test should be removed.
