### PR TITLE
By default log should be base10

### DIFF
--- a/src/compute-engine/compile.ts
+++ b/src/compute-engine/compile.ts
@@ -132,7 +132,7 @@ const NATIVE_JS_FUNCTIONS: CompiledFunctions = {
   Ln: 'Math.log',
   List: (args, compile) => `[${args.map((x) => compile(x)).join(', ')}]`,
   Log: (args, compile) => {
-    if (args.length === 1) return `Math.log(${compile(args[0])})`;
+    if (args.length === 1) return `Math.log10(${compile(args[0])})`;
     return `(Math.log(${compile(args[0])}) / Math.log(${compile(args[1])}))`;
   },
   LogGamma: '_SYS.lngamma',


### PR DESCRIPTION
Fixed a small compiling issue in cortexjs