### PR TITLE
fix: preservation of (verbatim) latex

### DIFF
--- a/src/compute-engine/boxed-expression/box.ts
+++ b/src/compute-engine/boxed-expression/box.ts
@@ -8,7 +8,11 @@ import {
   CanonicalOptions,
 } from './public';
 
-import { Expression, MathJsonIdentifier } from '../../math-json/types';
+import {
+  Expression,
+  ExpressionObject,
+  MathJsonIdentifier,
+} from '../../math-json/types';
 import { machineValue, missingIfEmpty } from '../../math-json/utils';
 import {
   isValidIdentifier,
@@ -384,16 +388,20 @@ export function box(
   // Box a MathJSON object literal
   //
   if (typeof expr === 'object') {
+    const metadata: Metadata = {
+      latex: (expr as ExpressionObject).latex,
+      wikidata: (expr as ExpressionObject).wikidata,
+    };
     if ('fn' in expr) {
       const [fnName, ...ops] = expr.fn;
       return canonicalForm(
-        boxFunction(ce, fnName, ops, { canonical, structural }),
+        boxFunction(ce, fnName, ops, { canonical, structural, metadata }),
         options.canonical!
       );
     }
-    if ('str' in expr) return new BoxedString(ce, expr.str);
-    if ('sym' in expr) return ce.symbol(expr.sym, { canonical });
-    if ('num' in expr) return ce.number(expr, { canonical });
+    if ('str' in expr) return new BoxedString(ce, expr.str, metadata);
+    if ('sym' in expr) return ce.symbol(expr.sym, { canonical, metadata });
+    if ('num' in expr) return ce.number(expr, { canonical, metadata });
 
     throw new Error(`Unexpected MathJSON object: ${JSON.stringify(expr)}`);
   }

--- a/src/math-json/utils.ts
+++ b/src/math-json/utils.ts
@@ -1,5 +1,6 @@
 import type {
   Expression,
+  ExpressionObject,
   MathJsonFunction,
   MathJsonIdentifier,
   MathJsonNumber,
@@ -39,6 +40,15 @@ export function isFunctionObject(
   expr: Expression | null
 ): expr is MathJsonFunction {
   return expr !== null && typeof expr === 'object' && 'fn' in expr;
+}
+
+export function isExpressionObject(
+  expr: Expression | null
+): expr is ExpressionObject {
+  const isObj = expr !== null && typeof expr === 'object';
+  return (
+    isObj && ('fn' in expr || 'num' in expr || 'sym' in expr || 'str' in expr)
+  );
 }
 
 /**  If expr is a string literal, return it.


### PR DESCRIPTION
Noticed that `verbatimLatex` not being saved on BoxedExpression instances created from `ce.parse` for some time. Looks as if this traceable to commits:

> cd557e5 - 'arch: changed JSON canonical format, APIs for serialization to LaTeX and MathJSON' (2024-06-25)

^Wherein there is retraction of passing of 'metadata' to `ce.box` from within `ce.parse`
And:

> e1f9e19 - 'arch' (2024-09-25)

^In which 'metadata' is retracted both as an argument to 'box' (the function) and its inner forwarding to BoxedExpression constructor calls when handling 'MathJSON object literals'.

As a guess, it appears to me that removing `metadata` as a parameter from `box` was apt due to these properties being foreseen as present on MathJSON object literals: if present at all. Looks however that in these changes that the step of checking for this meta elsewhere (i.e. object literals) is absent.
This '*fix*' is only an educated guess & seems to address the issue,

*But* this change/request also appears to **break** a single test-case within `test/compute-engine/latex-syntax/numbers.test.ts` - which I have not investigated - and thus is not suitable for merging.
(Note at the time of this request, the HEAD of main ([#115272d](https://github.com/cortex-js/compute-engine/commit/115272dd130ae69c13815d37814de57d3269abdc), there is already extant a single test failure (`test/compute-engine/functions.test.ts` -> `Apply -> Function and Hold`), which is not related to this change).

Single commit also includes an unused utility `isExpressionObject`, which was initially used, but could now be discarded. 