### PR TITLE
Optimize parsing of invisible operator operands

### DIFF
--- a/src/compute-engine/latex-syntax/dictionary/definitions-arithmetic.ts
+++ b/src/compute-engine/latex-syntax/dictionary/definitions-arithmetic.ts
@@ -18,6 +18,7 @@ import {
   Serializer,
   Parser,
   LatexDictionary,
+  INVISIBLE_OP_PRECEDENCE,
   MULTIPLICATION_PRECEDENCE,
   ADDITION_PRECEDENCE,
   ARROW_PRECEDENCE,
@@ -1153,7 +1154,7 @@ export const DEFINITIONS_ARITHMETIC: LatexDictionary = [
     latexTrigger: ['\\sum'],
     precedence: ADDITION_PRECEDENCE,
     name: 'Sum',
-    parse: parseBigOp('Sum', ADDITION_PRECEDENCE),
+    parse: parseBigOp('Sum', MULTIPLICATION_PRECEDENCE),
     serialize: serializeBigOp('\\sum'),
   },
   {
@@ -1265,7 +1266,7 @@ function getIndexes(
     .filter((x) => x !== undefined);
 }
 
-function parseBigOp(name: string, prec: number) {
+function parseBigOp(name: string, minPrec: number) {
   return (parser: Parser): Expression | null => {
     parser.skipSpace();
 
@@ -1292,7 +1293,7 @@ function parseBigOp(name: string, prec: number) {
     for (const indexinSet of indexes)
       parser.addSymbol(indexinSet.index, 'symbol');
 
-    const fn = parser.parseExpression({ minPrec: prec + 1 });
+    const fn = parser.parseExpression({ minPrec: minPrec });
 
     parser.popSymbolTable();
 

--- a/src/compute-engine/latex-syntax/parse.ts
+++ b/src/compute-engine/latex-syntax/parse.ts
@@ -19,6 +19,7 @@ import {
   Delimiter,
   Terminator,
   Parser,
+  INVISIBLE_OP_PRECEDENCE,
   MULTIPLICATION_PRECEDENCE,
   SymbolTable,
   SymbolType,
@@ -1356,7 +1357,7 @@ export class _Parser implements Parser {
 
       // No group, but arguments without parentheses are allowed
       // Read a primary
-      const primary = this.parseExpression({ ...until, minPrec: 390 });
+      const primary = this.parseExpression({ ...until, minPrec: MULTIPLICATION_PRECEDENCE });
       return primary === null ? null : [primary];
     }
 
@@ -1987,13 +1988,13 @@ export class _Parser implements Parser {
         this.skipSpace();
 
         let result = this.parseInfixOperator(lhs, until);
-        if (result === null) {
+        if (result === null && until.minPrec <= INVISIBLE_OP_PRECEDENCE) {
           // If any operator, no sequence to apply
           if (this.peekDefinitions('operator').length === 0) {
             // No infix operator, join the expressions with a Sequence
             const rhs = this.parseExpression({
               ...until,
-              minPrec: MULTIPLICATION_PRECEDENCE,
+              minPrec: INVISIBLE_OP_PRECEDENCE+1,
             });
             if (rhs !== null) {
               if (operator(lhs) === 'InvisibleOperator') {

--- a/src/compute-engine/latex-syntax/public.ts
+++ b/src/compute-engine/latex-syntax/public.ts
@@ -157,6 +157,7 @@ export const ARROW_PRECEDENCE: Precedence = 270;
 // + - − ¦ |\|| ⊕ ⊖ ⊞ ⊟ |++| ∪ ∨ ⊔ ± ∓ ∔ ∸ ≏ ⊎ ⊻ ⊽ ⋎ ⋓ ⟇ ⧺ ⧻ ⨈ ⨢ ⨣ ⨤ ⨥ ⨦ ⨧ ⨨ ⨩ ⨪ ⨫ ⨬ ⨭ ⨮ ⨹ ⨺ ⩁ ⩂ ⩅ ⩊ ⩌ ⩏ ⩐ ⩒ ⩔ ⩖ ⩗ ⩛ ⩝ ⩡ ⩢ ⩣)
 /** @hidden */
 export const ADDITION_PRECEDENCE: Precedence = 275;
+
 // * / ⌿ ÷ % & · · ⋅ ∘ × |\\| ∩ ∧ ⊗ ⊘ ⊙ ⊚ ⊛ ⊠ ⊡ ⊓ ∗ ∙ ∤ ⅋ ≀ ⊼ ⋄ ⋆ ⋇ ⋉ ⋊ ⋋ ⋌ ⋏ ⋒ ⟑ ⦸ ⦼ ⦾ ⦿ ⧶ ⧷ ⨇ ⨰ ⨱ ⨲ ⨳ ⨴ ⨵ ⨶ ⨷ ⨸ ⨻ ⨼ ⨽ ⩀ ⩃ ⩄ ⩋ ⩍ ⩎ ⩑ ⩓ ⩕ ⩘ ⩚ ⩜ ⩞ ⩟ ⩠ ⫛ ⊍ ▷ ⨝ ⟕ ⟖ ⟗ ⨟
 /** @hidden */
 export const MULTIPLICATION_PRECEDENCE: Precedence = 390;
@@ -164,6 +165,10 @@ export const MULTIPLICATION_PRECEDENCE: Precedence = 390;
 // Rational, Divide
 /** @hidden */
 export const DIVISION_PRECEDENCE: Precedence = 600;
+
+// The invisible (multiplication) operator
+/** @hidden */
+export const INVISIBLE_OP_PRECEDENCE: Precedence = 650;
 
 // Power, Square, Overscript
 /** @hidden */


### PR DESCRIPTION
Some expressions take a very long time to parse, scaling exponentially with the length of the expression.  The following example takes over 20 minutes to parse without this patch and less than a second with the patch.

    xxxxxxxxxxxxxxxx\left[yyyyyyyy\left[zzzzzzzzzz\left[\left[\left[x.x\right]\right]\right]\right]\right]

It is an invalid expression.  If that could be determined in general without attempting to parse it, perhaps the parsing efficiency wouldn't matter, but I don't know of a way to achieve that.

The cause of the blow-up in execution time is a combination of backtracking to the opening braces due to the invalid part of the expression and continued attempts to parse forward again due to the loop over invisible operator operands at every level in the recursive chain of parseExpression() calls.

This patch avoids many redundant attempts to parse the next invisible operator operand by only doing that in the parent parseExpression() and not in its immediate children.  This is implemented in a somewhat ad-hoc way rather than splitting the multiplication precedence level in two.  If you would like, I'd be happy to submit a patch that does the latter.  I think that will disturb more code, so that is why I did it this way.

Thanks for listening, and thanks for the wonderful software!