### PR TITLE
Draft: (partial) fix for 'ce.declare' with SymbolDefinition using prop. 'type'

### DIFF
--- a/src/common/type/utils.ts
+++ b/src/common/type/utils.ts
@@ -122,10 +122,11 @@ export function collectionElementType(type: Readonly<Type>): Type | undefined {
   return undefined;
 }
 
-export function isValidType(t: any): t is Readonly<Type> {
-  if (typeof t === 'string')
-    return PRIMITIVE_TYPES.includes(t as PrimitiveType);
-  if (typeof t !== 'object') return false;
+export function isValidType(t: unknown): t is Readonly<Type> {
+  const isObject = typeof t === 'object' && t !== null;
+  if (typeof t === 'string' || (isObject && 'type' in t))
+    return PRIMITIVE_TYPES.includes((isObject ? t.type : t) as PrimitiveType);
+  if (!isObject) return false;
   if (!('kind' in t)) return false;
   return (
     t.kind === 'signature' ||

--- a/src/compute-engine/compute-engine.ts
+++ b/src/compute-engine/compute-engine.ts
@@ -1371,8 +1371,10 @@ export class ComputeEngine implements IComputeEngine {
     if (
       typeof def === 'object' &&
       'type' in def &&
-      ((typeof def.type === 'string' && isSubtype(def.type, 'function')) ||
-        (def.type && isValidType(def.type)))
+      !(
+        (typeof def.type === 'string' && isSubtype(def.type, 'function')) ||
+        (def.type && isValidType(def.type))
+      )
     ) {
       throw new Error(
         `Invalid definition for "${id}": use a FunctionDefinition to define a function or use 'ce.declare("${id}", "function")'`


### PR DESCRIPTION
Noticed that `ce.declare` errors when supplying a _SymbolDefinition_ of form `{type: TypeString}` for second arg.

Current changes appear to address the issue, but appears to surface or reveal a few existing test errs. where throughout these, type values given through 'SymbolDefinition.type' do not conform to current type definitions: e.g. `{ type: 'set<integers>', ... }` is given whereas in this context, according to definition of the type '*Type*', a `{kind: 'set', elements: 'integers' }` is expected instead. Did try to investigate further but opened a bit of a can of worms.

Believe that almost all errs. can be addressed fairly easily with present changes, but may require some alterations.
For reference, for the commit at which this was branched, 4 'snapshot' errors were already present split between tests '*compute-engine/compile.test.ts*', and '*compute-engine/compile.test.ts*'. This change surfaces ~18 newer