### PR TITLE
fix: use the tolerance defined by ce in numeric chop

### DIFF
--- a/src/compute-engine/boxed-expression/terms.ts
+++ b/src/compute-engine/boxed-expression/terms.ts
@@ -185,8 +185,8 @@ function nvSum(
   const makeExact = (x) => new ExactNumericValue(x, factory, bignum);
   const factory =
     ce.precision > MACHINE_PRECISION
-      ? (x) => new BigNumericValue(x, bignum)
-      : (x) => new MachineNumericValue(x, makeExact);
+      ? (x) => new BigNumericValue(x, bignum, ce.tolerance)
+      : (x) => new MachineNumericValue(x, makeExact, ce.tolerance);
   return ExactNumericValue.sum(numericValues, factory, bignum);
 }
 
@@ -198,8 +198,8 @@ function nvSumN(
   const makeExact = (x) => new ExactNumericValue(x, factory, bignum);
   const factory =
     ce.precision > MACHINE_PRECISION
-      ? (x) => new BigNumericValue(x, bignum)
-      : (x) => new MachineNumericValue(x, makeExact);
+      ? (x) => new BigNumericValue(x, bignum, ce.tolerance)
+      : (x) => new MachineNumericValue(x, makeExact, ce.tolerance);
   const result = ExactNumericValue.sum(numericValues, factory, bignum);
 
   if (result.length === 0) return makeExact(0);

--- a/src/compute-engine/index.ts
+++ b/src/compute-engine/index.ts
@@ -882,8 +882,8 @@ export class ComputeEngine implements IComputeEngine {
     const bignum = (x) => this.bignum(x);
     const makeNumericValue =
       this._precision > MACHINE_PRECISION
-        ? (x) => new BigNumericValue(x, bignum)
-        : (x) => new MachineNumericValue(x, bignum);
+        ? (x) => new BigNumericValue(x, bignum, this.tolerance)
+        : (x) => new MachineNumericValue(x, bignum, this.tolerance);
 
     if (typeof value === 'number') {
       if (Number.isInteger(value))


### PR DESCRIPTION
This will close the issue #231.
While changing `DEFAULT_TOLERANCE` fixes the problem, `chop` in the calculation are still worrisome.