### PR TITLE
Feat/fix: revised canonical forms; tests; preliminary & associated fixes

### DIFF
--- a/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
+++ b/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
@@ -661,10 +661,6 @@ export abstract class _BoxedExpression implements BoxedExpression {
     throw new Error(`Can't change the value of \\(${this.latex}\\)`);
   }
 
-  get constantValue(): number | boolean | string | object | undefined {
-    return undefined;
-  }
-
   get type(): BoxedType {
     return BoxedType.unknown;
   }

--- a/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
+++ b/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
@@ -224,7 +224,7 @@ export abstract class _BoxedExpression implements BoxedExpression {
   toLatex(options?: Partial<SerializeLatexOptions>): LatexString {
     // We want to use toMathJson(), not .json, so that we have all
     // the digits for numbers, repeated decimals
-    const json = this.toMathJson();
+    const json = this.toMathJson({ prettify: options?.prettify ?? true });
 
     let effectiveOptions: SerializeLatexOptions = {
       imaginaryUnit: '\\imaginaryI',
@@ -249,7 +249,7 @@ export abstract class _BoxedExpression implements BoxedExpression {
       notation: 'auto',
       avoidExponentsInRange: [-7, 20],
 
-      prettify: true,
+      prettify: true, // (overridden subseq. by options)
 
       invisibleMultiply: '', // '\\cdot',
       invisiblePlus: '', // '+',

--- a/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
+++ b/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
@@ -419,10 +419,6 @@ export abstract class _BoxedExpression implements BoxedExpression {
     return false;
   }
 
-  /** Literals (number, string, boolean) are constants. Some symbols
-   * may also be constants (e.g. Pi, E, True, False). Expressions of constant
-   * symbols are also constants (if the function is pure).
-   */
   get isConstant(): boolean {
     return true;
   }

--- a/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
+++ b/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
@@ -665,6 +665,10 @@ export abstract class _BoxedExpression implements BoxedExpression {
     throw new Error(`Can't change the value of \\(${this.latex}\\)`);
   }
 
+  get constantValue(): number | boolean | string | object | undefined {
+    return undefined;
+  }
+
   get type(): BoxedType {
     return BoxedType.unknown;
   }

--- a/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
+++ b/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
@@ -134,7 +134,7 @@ export abstract class _BoxedExpression implements BoxedExpression {
     if (this.isInfinity) {
       if (this.isPositive) return Infinity;
       if (this.isNegative) return -Infinity;
-      return NaN;
+      return '~oo'; // ComplexInfinity
     }
     if (typeof this.string === 'string') return this.string;
     if (typeof this.symbol === 'string') return this.symbol;

--- a/src/compute-engine/boxed-expression/box.ts
+++ b/src/compute-engine/boxed-expression/box.ts
@@ -191,17 +191,15 @@ export function boxFunction(
   //
   if (name === 'Number' && ops.length === 1) return box(ce, ops[0], options);
 
-  const canonicalNumber =
-    structural === false &&
-    (options.canonical === true ||
-      options.canonical === 'Number' ||
-      (Array.isArray(options.canonical) &&
-        options.canonical.includes('Number')));
+  const canonicalNumber = structural === false && options.canonical === true;
 
+  // If canonical, handle cases of various expression structures being able to be cast as
+  // BoxedNumbers (some cases of Negate, Rational, Divide, Complex), or 'de-number' some 'borderline
+  // invalid' boxed number-like expressions
+  // (!@note: this procedure is similarly repeated within the 'number' CanonicalForm, but the
+  // numberForm variant more simply applies to fully BoxedExprs., and during partial canonicalization
+  // only)
   if (canonicalNumber) {
-    // If we have a full canonical form or a canonical form for numbers
-    // do some additional simplifications
-
     //
     // Rational (as Divide)
     //

--- a/src/compute-engine/boxed-expression/boxed-function.ts
+++ b/src/compute-engine/boxed-expression/boxed-function.ts
@@ -218,6 +218,10 @@ export class BoxedFunction extends _BoxedExpression {
     return this._ops.every((x) => x.isConstant);
   }
 
+  get constantValue(): number | boolean | string | object | undefined {
+    return this.isConstant ? this.value : undefined;
+  }
+
   get json(): Expression {
     return [this._name, ...this.structural.ops!.map((x) => x.json)];
   }
@@ -697,7 +701,6 @@ export class BoxedFunction extends _BoxedExpression {
       const ops = this.ops.map((x) => x.root(exp));
       return mul(...ops);
     }
-
 
     if (this.isNumberLiteral) {
       const v = this.numericValue!;

--- a/src/compute-engine/boxed-expression/boxed-function.ts
+++ b/src/compute-engine/boxed-expression/boxed-function.ts
@@ -681,10 +681,16 @@ export class BoxedFunction extends _BoxedExpression {
       }
     }
 
-    // (√a)^b -> a^(b/2) or √(a^b)
-    if (this.operator === 'Sqrt') {
-      if (e !== undefined) return this.op1.root(e + 2);
-      if (typeof exp !== 'number') return this.op1.root(exp.add(2));
+    // root(sqrt(a), c) -> root(a, 2*c)
+    if (this.operator === 'Sqrt' || this.operator === 'Root') {
+      if (e !== undefined) return this.op1.root(e * 2);
+      if (typeof exp !== 'number') return this.op1.root(exp.mul(2));
+    }
+
+    // root(root(a, b), c) -> root(a, b*c)
+    if (this.operator === 'Root') {
+      const [base, root] = this.ops;
+      return base.root(root.mul(exp));
     }
 
     if (this.operator === 'Multiply') {
@@ -692,10 +698,6 @@ export class BoxedFunction extends _BoxedExpression {
       return mul(...ops);
     }
 
-    if (this.operator === 'Root') {
-      const [base, root] = this.ops;
-      return base.root(root.mul(exp));
-    }
 
     if (this.isNumberLiteral) {
       const v = this.numericValue!;

--- a/src/compute-engine/boxed-expression/boxed-number.ts
+++ b/src/compute-engine/boxed-expression/boxed-number.ts
@@ -128,8 +128,28 @@ export class BoxedNumber extends _BoxedExpression {
     return 1;
   }
 
+  /**
+   *
+   * **note**: For BoxedNumbers, returns a number literal if this can be represented in JavaScript
+   * as such (most cases); else returns a string (ComplexInfinity, complex-numbers, for example).
+   *
+   * @inheritdoc
+   *
+   * <!--
+   * (note: overrides parent 'value' - despite identical body - to narrow return-type & add
+   * documenation)
+   * -->
+   */
+  get value(): number | string {
+    return this.N().valueOf();
+  }
+
   get numericValue(): number | NumericValue {
     return this._value;
+  }
+
+  get constantValue(): number {
+    return this.value as number;
   }
 
   get isNumberLiteral(): boolean {

--- a/src/compute-engine/boxed-expression/boxed-number.ts
+++ b/src/compute-engine/boxed-expression/boxed-number.ts
@@ -385,11 +385,20 @@ export class BoxedNumber extends _BoxedExpression {
     let s: number | undefined;
     if (typeof this._value === 'number') {
       if (Number.isNaN(this._value)) return 'nan';
+      if (this._value === +Infinity) return 'positive-infinity';
+      if (this._value === -Infinity) return 'negative-infinity';
       s = Math.sign(this._value);
-    } else s = this._value.sgn();
-    // The sign of a complex Numeric Value is `undefined`
-    if (s === undefined) return 'unsigned';
+    } else s = this._value.sgn(); // 'NumericValue'
+
+    // indicates a complex Numeric Value
+    // aside from 'complex-infinity', will be 'unsigned'
+    if (s === undefined) {
+      if ((this._value as NumericValue).isComplexInfinity)
+        return 'complex-infinity';
+      return 'unsigned';
+    }
     if (Number.isNaN(s)) return 'unsigned';
+    //Should leave only the reals
     if (s === 0) return 'zero';
     if (s > 0) return 'positive';
     return 'negative';

--- a/src/compute-engine/boxed-expression/boxed-number.ts
+++ b/src/compute-engine/boxed-expression/boxed-number.ts
@@ -364,7 +364,7 @@ export class BoxedNumber extends _BoxedExpression {
 
     let s: number | undefined;
     if (typeof this._value === 'number') {
-      if (Number.isNaN(this._value)) return 'unsigned';
+      if (Number.isNaN(this._value)) return 'nan';
       s = Math.sign(this._value);
     } else s = this._value.sgn();
     // The sign of a complex Numeric Value is `undefined`

--- a/src/compute-engine/boxed-expression/boxed-number.ts
+++ b/src/compute-engine/boxed-expression/boxed-number.ts
@@ -591,7 +591,10 @@ export class BoxedNumber extends _BoxedExpression {
   N(): BoxedExpression {
     const v = this._value;
     if (typeof v === 'number') return this;
+    //NumericValue
     const n = v.N();
+    //Often, 'evaluating' a numeric-value yields the same result, but sometimes may result in a
+    //different representation: e.g. some cases of Exact -> Big
     if (v === n) return this;
     return this.engine.number(n);
   }

--- a/src/compute-engine/boxed-expression/boxed-number.ts
+++ b/src/compute-engine/boxed-expression/boxed-number.ts
@@ -148,10 +148,6 @@ export class BoxedNumber extends _BoxedExpression {
     return this._value;
   }
 
-  get constantValue(): number {
-    return this.value as number;
-  }
-
   get isNumberLiteral(): boolean {
     return true;
   }

--- a/src/compute-engine/boxed-expression/boxed-string.ts
+++ b/src/compute-engine/boxed-expression/boxed-string.ts
@@ -45,6 +45,10 @@ export class BoxedString extends _BoxedExpression {
     return;
   }
 
+  get constantValue(): string {
+    return this.value as string;
+  }
+
   get type(): BoxedType {
     return new BoxedType('string');
   }

--- a/src/compute-engine/boxed-expression/boxed-string.ts
+++ b/src/compute-engine/boxed-expression/boxed-string.ts
@@ -45,10 +45,6 @@ export class BoxedString extends _BoxedExpression {
     return;
   }
 
-  get constantValue(): string {
-    return this.value as string;
-  }
-
   get type(): BoxedType {
     return new BoxedType('string');
   }

--- a/src/compute-engine/boxed-expression/boxed-symbol.ts
+++ b/src/compute-engine/boxed-expression/boxed-symbol.ts
@@ -414,10 +414,13 @@ export class BoxedSymbol extends _BoxedExpression {
   }
 
   /**
+   *
    * Subsequent inferences will narrow the domain of the symbol.
    * f: integer -> real, g: real -> real
    * g(x) => x: real
    * f(x) => x: integer narrowed from integer to real
+   *
+   * @inheritdoc
    */
   infer(t: Type): boolean {
     // Call _lookupDef() to *not* auto-bind the symbol
@@ -437,7 +440,8 @@ export class BoxedSymbol extends _BoxedExpression {
     // Widen the type, if it was previously inferred
     if (
       def instanceof _BoxedSymbolDefinition &&
-      (def.inferredType || def.type.isUnknown)
+      (def.inferredType || def.type.isUnknown) &&
+      !def.isConstant //'constant' symbols may still be inferred (i.e. value given but no type)
     ) {
       def.type = widen(def.type.type, t);
       return true;

--- a/src/compute-engine/boxed-expression/boxed-symbol.ts
+++ b/src/compute-engine/boxed-expression/boxed-symbol.ts
@@ -531,18 +531,6 @@ export class BoxedSymbol extends _BoxedExpression {
     }
   }
 
-  /**
-   *
-   * :::info[Note]
-   * Will bind this symbol *if* this is a constant.
-   * :::
-   *
-   * @inheritdoc
-   */
-  get constantValue(): number | boolean | string | object | undefined {
-    return this.isConstant ? this.value : undefined;
-  }
-
   // The type of the value of the symbol.
   // If the symbol is not bound to a definition, the type is 'unknown'
   get type(): BoxedType {

--- a/src/compute-engine/boxed-expression/boxed-symbol.ts
+++ b/src/compute-engine/boxed-expression/boxed-symbol.ts
@@ -527,6 +527,18 @@ export class BoxedSymbol extends _BoxedExpression {
     }
   }
 
+  /**
+   *
+   * :::info[Note]
+   * Will bind this symbol *if* this is a constant.
+   * :::
+   *
+   * @inheritdoc
+   */
+  get constantValue(): number | boolean | string | object | undefined {
+    return this.isConstant ? this.value : undefined;
+  }
+
   // The type of the value of the symbol.
   // If the symbol is not bound to a definition, the type is 'unknown'
   get type(): BoxedType {

--- a/src/compute-engine/boxed-expression/boxed-tensor.ts
+++ b/src/compute-engine/boxed-expression/boxed-tensor.ts
@@ -126,10 +126,6 @@ export class BoxedTensor extends _BoxedExpression {
     );
   }
 
-  get constantValue() {
-    return this.value;
-  }
-
   get isCanonical(): boolean {
     if (this._tensor) return true;
     return this._expression!.isCanonical;

--- a/src/compute-engine/boxed-expression/boxed-tensor.ts
+++ b/src/compute-engine/boxed-expression/boxed-tensor.ts
@@ -126,6 +126,10 @@ export class BoxedTensor extends _BoxedExpression {
     );
   }
 
+  get constantValue() {
+    return this.value;
+  }
+
   get isCanonical(): boolean {
     if (this._tensor) return true;
     return this._expression!.isCanonical;

--- a/src/compute-engine/boxed-expression/canonical.ts
+++ b/src/compute-engine/boxed-expression/canonical.ts
@@ -2,6 +2,7 @@ import { flattenOps } from './flatten';
 
 import { canonicalAdd } from './arithmetic-add';
 import { canonicalMultiply, canonicalDivide } from './arithmetic-mul-div';
+import { canonicalPower } from './arithmetic-power';
 import { canonicalInvisibleOperator } from '../library/invisible-operator';
 
 import { canonicalOrder } from './order';
@@ -230,14 +231,12 @@ function addForm(expr: BoxedExpression) {
 function powerForm(expr: BoxedExpression) {
   if (!expr.ops) return expr;
 
+  const ops = expr.ops.map((expr) => powerForm(expr));
+
   // If this is a power, canonicalize it
-  if (expr.operator === 'Power')
-    return powerForm(expr.op1).pow(powerForm(expr.op2));
+  if (expr.operator === 'Power') return canonicalPower(ops[0], ops[1]);
 
-  // Recursively visit all sub-expressions
-  if (!expr.ops) return expr;
-
-  return expr.engine._fn(expr.operator, expr.ops.map(powerForm));
+  return expr.engine._fn(expr.operator, ops, { canonical: false });
 }
 
 function divideForm(expr: BoxedExpression) {

--- a/src/compute-engine/boxed-expression/canonical.ts
+++ b/src/compute-engine/boxed-expression/canonical.ts
@@ -5,6 +5,7 @@ import { canonicalMultiply, canonicalDivide } from './arithmetic-mul-div';
 import { canonicalInvisibleOperator } from '../library/invisible-operator';
 
 import { canonicalOrder } from './order';
+import { asBigint } from './numerics';
 import type { BoxedExpression, CanonicalOptions } from '../global-types';
 
 export function canonicalForm(
@@ -105,13 +106,93 @@ function invisibleOperatorForm(expr: BoxedExpression) {
   return expr.engine._fn(expr.operator, expr.ops.map(invisibleOperatorForm));
 }
 
-function numberForm(expr: BoxedExpression) {
-  // Return the canonical form if a number literal
+/**
+ * Apply the 'Number' form to the expression, _recursively_.
+ *
+ * This involes casting as numbers various (non-BoxedNumber) expression structures, such as:
+ *
+ * This includes :
+ * - Expressions with an operator of `Complex` are converted to a (complex) number
+ *     or a `Add`/`Multiply` expression.
+ *
+ * - An expression with a `Rational` operator is converted to a rational
+ *    number if possible, and to a `Divide` otherwise.
+ *
+ * - A `Negate` function applied to a number literal is converted to a number.
+ *
+ * <!--
+ * (!note: the procedure outlined is a contracted one of that affixed to function 'box')
+ * -->
+ *
+ * @param expr
+ * @returns
+ */
+function numberForm(expr: BoxedExpression): BoxedExpression {
+  //(↓note: this is redundant, since numbers are _always_ boxed as canonical (v27.0), but preserving
+  //for explicitness in case things change)
   if (expr.isNumberLiteral) return expr.canonical;
 
+  if (!expr.isFunctionExpression) return expr;
+
+  const { engine: ce } = expr;
+
   // Recursively visit all sub-expressions
-  if (expr.ops) return expr.engine._fn(expr.operator, expr.ops.map(numberForm));
-  return expr;
+  const ops = expr.ops!.map(numberForm);
+  let { operator: name } = expr;
+
+  //
+  // Rational (as Divide)
+  //
+  if ((name === 'Divide' || name === 'Rational') && ops.length === 2) {
+    const n = asBigint(ops[0]);
+    if (n !== null) {
+      const d = asBigint(ops[1]);
+      if (d !== null) return ce.number([n, d]);
+    }
+    name = 'Divide';
+  }
+
+  //
+  // Complex
+  //
+  if (name === 'Complex') {
+    if (ops.length === 1) {
+      // If single argument, assume it's imaginary
+      const op1 = ops[0];
+      if (op1.isNumberLiteral) return ce.number(ce.complex(0, op1.re));
+
+      return op1.mul(ce.I);
+    }
+    if (ops.length === 2) {
+      const re = ops[0].re;
+      const im = ops[1].re;
+      if (im !== null && re !== null && !isNaN(im) && !isNaN(re)) {
+        if (im === 0 && re === 0) return ce.Zero;
+        if (im !== 0) return ce.number(ce._numericValue({ re, im }));
+        return ops[0];
+      }
+      return ops[0].add(ops[1].mul(ce.I));
+    }
+    throw new Error('Expected one or two arguments with Complex expression');
+  }
+
+  //
+  // Negate
+  //
+  // Distribute over literals
+  //
+  if (name === 'Negate' && ops.length === 1) {
+    const op1 = ops[0]!;
+    const { numericValue } = op1;
+    if (numericValue !== null)
+      return ce.number(
+        typeof numericValue === 'number' ? -numericValue : numericValue.neg()
+      );
+  }
+
+  return ops.every((op, index) => op === expr.ops![index])
+    ? expr
+    : ce._fn(name, ops, { canonical: false });
 }
 
 function multiplyForm(expr: BoxedExpression) {

--- a/src/compute-engine/boxed-expression/sgn.ts
+++ b/src/compute-engine/boxed-expression/sgn.ts
@@ -44,63 +44,110 @@ export function infinitySgn(s: Sign | undefined): boolean | undefined {
   );
 }
 
-// > 0
+/**
+ * Sign `s` is > 0.
+ *
+ * :::info[Note]
+ * Returns `undefined` for cases where the given sign is either non-applicable to real numbers
+ * ('nan', 'unsigned', 'complex-infinity') or does not convey enough information (e.g. 'real',
+ * 'not-zero', 'real-not-zero', 'non-negative').
+ * :::
+ *
+ * @param s
+ */
 export function positiveSign(s: Sign | undefined): boolean | undefined {
   if (s === undefined) return undefined;
 
-  if (s === 'positive') return true;
+  if (s === 'positive' || s === 'positive-infinity') return true;
   if (
-    [
-      'non-positive',
-      'zero',
-      'unsigned',
-      'negative',
-      'negative-infinity',
-    ].includes(s)
+    (
+      ['non-positive', 'zero', 'negative', 'negative-infinity'] as Sign[]
+    ).includes(s)
   )
     return false;
 
+  //Case for 'nan', signs for complex numbers ('unsigned', 'complex-infinity'), or sign does not
+  //convey enough info. (e.g. 'real', 'not-zero', 'real-not-zero')
   return undefined;
 }
 
-// >= 0
+/**
+ * Sign `s` is >= 0.
+ *
+ *
+ * **note**: returns *undefined* where sign does not apply to the field of reals, or does not convey
+ * enough information.
+ *
+ * @param s
+ */
 export function nonNegativeSign(s: Sign | undefined): boolean | undefined {
   if (s === undefined) return undefined;
 
-  if (s === 'positive' || s === 'positive-infinity' || s === 'non-negative')
+  if (
+    (
+      ['positive', 'positive-infinity', 'non-negative', 'zero'] as Sign[]
+    ).includes(s)
+  )
     return true;
-  if (['negative', 'negative-infinity', 'zero', 'unsigned'].includes(s))
-    return false;
+  if ((['negative', 'negative-infinity'] as Sign[]).includes(s)) return false;
 
+  //Case for 'nan', complex numbers ('unsigned', 'complex-infinity', maybe 'not-zero'), or sign does not
+  //convey enough info. (e.g. 'non-positive','real', 'real-not-zero')
   return undefined;
 }
 
-// < 0
+/**
+ * Sign `s` is < 0.
+ *
+ * :::info[Note]
+ * Returns `undefined` for cases where the given sign is either non-applicable to real numbers
+ * ('nan', 'unsigned', 'complex-infinity') or does not convey enough information (e.g. 'real',
+ * 'not-zero', 'real-not-zero', 'non-positive').
+ * :::
+ *
+ * @param s
+ */
 export function negativeSign(s: Sign | undefined): boolean | undefined {
   if (s === undefined) return undefined;
 
   if (s === 'negative' || s === 'negative-infinity') return true;
   if (
-    [
-      'non-negative',
-      'zero',
-      'unsigned',
-      'positive',
-      'positive-infinity',
-    ].includes(s)
+    (
+      ['non-negative', 'zero', 'positive', 'positive-infinity'] as Sign[]
+    ).includes(s)
   )
     return false;
 
+  //'nan', 'unsigned','complex-infinity', or not enough info: 'real-not-zero', 'non-positive', etc.
   return undefined;
 }
 
-// <= 0
+/**
+ * Sign `s` is <= 0.
+ *
+ *
+ * **note**: returns *undefined* where sign does not apply to the field of reals, or does not convey
+ * enough information.
+ *
+ * @param s
+ */
 export function nonPositiveSign(s: Sign | undefined): boolean | undefined {
   if (s === undefined) return undefined;
 
-  if (s === 'negative' || s === 'negative-infinity' || s === 'non-positive')
+  if (
+    (
+      [
+        'negative',
+        'negative-infinity',
+        'non-positive',
+        'zero',
+      ] as Sign[] as Sign[]
+    ).includes(s)
+  )
     return true;
-  if (['positive', 'zero', 'unsigned'].includes(s)) return false;
+  //Definitely positive
+  if ((['positive', 'positive-infinity'] as Sign[]).includes(s)) return false;
 
+  //'nan', a complex-number sign, or a sign not conveying sufficient info.
   return undefined;
 }

--- a/src/compute-engine/boxed-expression/sgn.ts
+++ b/src/compute-engine/boxed-expression/sgn.ts
@@ -35,6 +35,15 @@ export function sgn(expr: BoxedExpression): Sign | undefined {
   return 'unsigned';
 }
 
+export function infinitySgn(s: Sign | undefined): boolean | undefined {
+  if (s === undefined) return undefined;
+  return (
+    s === 'positive-infinity' ||
+    s === 'negative-infinity' ||
+    s === 'complex-infinity'
+  );
+}
+
 // > 0
 export function positiveSign(s: Sign | undefined): boolean | undefined {
   if (s === undefined) return undefined;

--- a/src/compute-engine/boxed-expression/utils.ts
+++ b/src/compute-engine/boxed-expression/utils.ts
@@ -5,6 +5,7 @@ import type {
   SymbolDefinition,
   NumericFlags,
   ComputeEngine,
+  Metadata,
 } from '../global-types';
 
 import { joinLatex } from '../latex-syntax/tokenizer';
@@ -44,6 +45,20 @@ export function asLatexString(s: unknown): string | null {
     return asLatexString(joinLatex(s));
   }
   return null;
+}
+
+/**
+ *
+ *
+ * @export
+ * @param expr
+ * @returns
+ */
+export function getMeta(expr: BoxedExpression): Partial<Metadata> {
+  const result: Partial<Metadata> = {};
+  if (expr.verbatimLatex !== undefined) result.latex = expr.verbatimLatex;
+  if (expr.wikidata !== undefined) result.latex = expr.wikidata;
+  return result;
 }
 
 export function hashCode(s: string): number {

--- a/src/compute-engine/boxed-expression/utils.ts
+++ b/src/compute-engine/boxed-expression/utils.ts
@@ -186,6 +186,29 @@ export function getImaginaryFactor(
   return undefined;
 }
 
+/**
+ * `true` if expr is a number with imaginary part 1 and real part 0, or a symbol with a definition
+ * matching this. Does not bind expr if a symbol.
+ *
+ * @export
+ * @param expr
+ * @returns
+ */
+export function isImaginaryUnit(expr: BoxedExpression): boolean {
+  const { engine } = expr;
+  // Shortcut: boxed engine imaginary unit
+  if (expr === engine.I) return true;
+
+  if (expr.isNumberLiteral) return expr.re === 0 && expr.im === 1;
+
+  // !note: use 'isSame' instead of checking identity with 'I', to account for potential,
+  // non-default definition of the imaginary unit
+  if (expr.symbol !== null) return expr.canonical.isSame(engine.I);
+
+  // function/string/...
+  return false;
+}
+
 export function normalizeFlags(
   flags: Partial<NumericFlags> | undefined
 ): NumericFlags | undefined {

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -530,7 +530,7 @@ export interface BoxedExpression {
    * value of other expression changes or for other reasons.
    *
    * If `this.isPure` is `false`, `this.value` is undefined. Call
-   * `this.evaluate()` to determine the value of the expression instead.
+   * `this.evaluate()` (or '*this.N()*') to determine the value of the expression instead.
    *
    * As an example, the `Random` function is not pure.
    *
@@ -541,15 +541,18 @@ export interface BoxedExpression {
   readonly isPure: boolean;
 
   /**
-   * True if the the value of the expression does not depend on the value of
-   * any other expression.
+   * `True` if this expression's value remains constant.
    *
-   * For example, a number literal, a symbol with a constant value.
+   * If *true* and a function, implies that it is *pure*, and also that all of its arguments are
+   * constant.
+   *
+   * Number literals, symbols with constant values, and numeric functions with constant
+   * subexpressions may all be considered *constant*, i.e.:
    * - `2` is constant
    * - `Pi` is constant
    * - `["Add", "Pi", 2]` is constant
-   * - `x` is not constant
-   * - `["Add", "x", 2]` is not constant
+   * - `x` is inconstant: unless declared with a constant value.
+   * - `["Add", "x", 2]` is either constant or inconstant, depending on whether `x` is constant.
    */
   readonly isConstant: boolean;
 
@@ -1222,6 +1225,14 @@ export interface BoxedExpression {
    * Return a JavaScript primitive representing the value of this expression.
    *
    * Equivalent to `expr.N().valueOf()`.
+   *
+   * For functions, will only return non-undefined (i.e., compute the value) if the function is pure.
+   *
+   * For symbols, the current behaviour also considers *non-constant* values, including those weakly
+   * assigned via symbol assumptions.
+   *
+   * **note**: this property is not guaranteed to remain constant, potentially differing across
+   * subsequent calls if a symbol (non-constant), or an *inconstant* pure function.
    *
    */
   get value(): number | boolean | string | object | undefined;

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -1238,6 +1238,16 @@ export interface BoxedExpression {
   );
 
   /**
+   * Returns the JavaScript primitive value representative of this expression, but only if its value
+   * is a __constant__ one.
+   *
+   * Therefore, returns the same as 'value', but returns `undefined` for non-constant symbols, and
+   * impure functions.
+   *
+   */
+  get constantValue(): number | boolean | string | object | undefined;
+
+  /**
    *
    * The type of the value of this expression.
    *

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -2414,7 +2414,8 @@ export type RuntimeScope = Scope & {
  *
  * - `InvisibleOperator`: replace use of the `InvisibleOperator` with
  *    another operation, such as multiplication (i.e. `2x` or function
- *    application (`f(x)`).
+ *    application (`f(x)`). Also replaces ['InvisibleOperator', real, imaginary] instances with
+ *    complex (imaginary) numbers.
  * - `Number`: replace all numeric values with their
  *    canonical representation, for example, reduce
  *    rationals and replace complex numbers with no imaginary part with a real number.
@@ -2643,6 +2644,7 @@ export interface ComputeEngine extends IBigNum {
   readonly One: BoxedExpression;
   readonly Half: BoxedExpression;
   readonly NegativeOne: BoxedExpression;
+  /** ImaginaryUnit */
   readonly I: BoxedExpression;
   readonly NaN: BoxedExpression;
   readonly PositiveInfinity: BoxedExpression;

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -719,7 +719,7 @@ export interface BoxedExpression {
   readonly isNaN: boolean | undefined;
 
   /**
-   * The numeric value of this expression is `±Infinity` or Complex Infinity.
+   * The numeric value of this expression is `±Infinity` or ComplexInfinity.
    *
    * If this is a symbol, causes it to be bound to a definition.
    *
@@ -727,7 +727,7 @@ export interface BoxedExpression {
    */
   readonly isInfinity: boolean | undefined;
 
-  /** This expression is a number, but not `±Infinity`, 'ComplexInfinity` or
+  /** This expression is a number, but not `±Infinity`, `ComplexInfinity` or
    *  `NaN`
    *
    * @category Numeric Expression

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -1261,16 +1261,6 @@ export interface BoxedExpression {
   );
 
   /**
-   * Returns the JavaScript primitive value representative of this expression, but only if its value
-   * is a __constant__ one.
-   *
-   * Therefore, returns the same as 'value', but returns `undefined` for non-constant symbols, and
-   * impure functions.
-   *
-   */
-  get constantValue(): number | boolean | string | object | undefined;
-
-  /**
    *
    * The type of the value of this expression.
    *

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -1048,12 +1048,24 @@ export interface BoxedExpression {
    *
    * Infer the type of this expression.
    *
-   * If the type of this expression is already known, return `false`.
+   * Effective only for overall BoxedExpression types which are *non-constant* and therefore for
+   * which its value, and thereby type, can potentially vary.
    *
-   * If the type was not set, set it to the inferred type, return `true`
-   * If the type was previously inferred, widen it and return `true`.
+   * For symbols, inference may take place only for undeclared, or previously inferred symbols. For
+   * functions, only to those with an *inferred signature*.
    *
-   * If the type cannot be inferred, return `false`.
+   * For a successful inference, *widens* the type for symbols (including creating a symbol
+   * definition if this is an _undeclared_ boxed-symbol), and for functions, narrows the *(return)
+   * type*. The return result will for this case be `true`.
+   *
+   * (Note that subsequent inferences can be made and will override previous ones if valid)
+   *
+   * If inference is possible but the given type is incompatible with the declared or previously
+   * inferred type, will return `false`.
+   *
+   * For all other cases, such as inference for a constant-valued symbol, or a function already with
+   * a definition, returns `false`.
+   *
    *
    * @internal
    */

--- a/src/compute-engine/index.ts
+++ b/src/compute-engine/index.ts
@@ -1870,7 +1870,7 @@ export class ComputeEngine implements IComputeEngine {
     // Identifiers such as symbol names should use the Unicode NFC canonical form
     name = name.normalize();
 
-    // These three are not symbols (some of them are not even valid
+    // These few are not symbols (some of them are not even valid
     // identifiers) but they're a common type
     if (name === 'NaN') return this.NaN;
     if (
@@ -1881,6 +1881,7 @@ export class ComputeEngine implements IComputeEngine {
       return this.PositiveInfinity;
     if (name === '-Infinity' || name === 'NegativeInfinity')
       return this.NegativeInfinity;
+    if (name === 'ComplexInfinity') return this.ComplexInfinity;
 
     // `Half` is a synonym for the rational 1/2
     if (name === 'Half') return this.Half;

--- a/src/compute-engine/index.ts
+++ b/src/compute-engine/index.ts
@@ -2175,7 +2175,7 @@ export class ComputeEngine implements IComputeEngine {
     }
   }
 
-  /** Remove all assumptions about one or more symbols */
+  /** Remove all assumptions (in the current scope) about one or more symbols */
   forget(symbol: undefined | string | string[]): void {
     if (!this.context) throw Error('No scope available');
 

--- a/src/compute-engine/library/arithmetic.ts
+++ b/src/compute-engine/library/arithmetic.ts
@@ -877,6 +877,7 @@ export const ARITHMETIC_LIBRARY: IdentifierDefinitions[] = [
       canonical: (args, { engine }) => {
         args = checkNumericArgs(engine, args, 2);
         const [base, exp] = args;
+        //note: args. are canonicalized prior.
         return canonicalRoot(base, exp);
       },
       evaluate: ([x, n], { numericApproximation }) =>
@@ -1046,6 +1047,7 @@ export const ARITHMETIC_LIBRARY: IdentifierDefinitions[] = [
       value: (engine) => engine.I,
     },
 
+    //Alias of 'ImaginaryUnit'
     i: {
       type: 'imaginary',
       constant: true,

--- a/src/compute-engine/library/invisible-operator.ts
+++ b/src/compute-engine/library/invisible-operator.ts
@@ -1,4 +1,5 @@
 import { flatten } from '../boxed-expression/flatten';
+import { isImaginaryUnit } from '../boxed-expression/utils';
 import { isIndexableCollection } from '../collection-utils';
 import type { BoxedExpression, ComputeEngine } from '../global-types';
 
@@ -38,13 +39,11 @@ export function canonicalInvisibleOperator(
     }
 
     //
-    // Is it a complex number, i.e. "2i"?
+    // Is it a complex (imaginary) number, i.e. "2i"?
     //
     const rhs = ops[1];
-    if (!Number.isNaN(lhsInteger)) {
-      const canonicalRhs = rhs.canonical;
-      if (canonicalRhs.re === 0 && canonicalRhs.im === 1)
-        return ce.number(ce.complex(0, lhsInteger));
+    if (!Number.isNaN(lhsInteger) && isImaginaryUnit(rhs)) {
+      return ce.number(ce.complex(0, lhsInteger));
     }
 
     //

--- a/src/compute-engine/numeric-value/machine-numeric-value.ts
+++ b/src/compute-engine/numeric-value/machine-numeric-value.ts
@@ -10,6 +10,7 @@ import { ExactNumericValue } from './exact-numeric-value';
 export class MachineNumericValue extends NumericValue {
   __brand: 'MachineNumericValue';
 
+  // synonymous with 're'; the JavasScript number representation of the 'real' part.
   decimal: number;
   im: number;
 

--- a/test/compute-engine/__snapshots__/arithmetic.test.ts.snap
+++ b/test/compute-engine/__snapshots__/arithmetic.test.ts.snap
@@ -335,6 +335,7 @@ N-mach    = [3.00416602394643,7.3890560989306495,54.59815003314423]
 
 exports[`EXP Exp -1 1`] = `
 box       = ["Exp", -1]
+canonical = ["Divide", 1, "ExponentialE"]
 eval-auto = 1 / e
 eval-mach = 1 / e
 N-auto    = 0.367879441171442321596

--- a/test/compute-engine/ascii-math.test.ts
+++ b/test/compute-engine/ascii-math.test.ts
@@ -120,9 +120,9 @@ describe('POWERS/ROOTS', () => {
     expect(check('x+(-1)^2')).toMatchInlineSnapshot(`x + (-1)^2`);
   });
   it('should serialize other powers', () => {
-    expect(check('x^{0}')).toMatchInlineSnapshot(`1`);
+    expect(check('x^{0}')).toMatchInlineSnapshot(`x^0`);
     expect(check('x^{1}')).toMatchInlineSnapshot(`x`);
-    expect(check('x^{-1}')).toMatchInlineSnapshot(`x^(-1)`);
+    expect(check('x^{-1}')).toMatchInlineSnapshot(`1 / x`);
     expect(check('x^{1.1}')).toMatchInlineSnapshot(`x^(1.1)`);
     expect(check('x^{\\pi}')).toMatchInlineSnapshot(`x^(pi)`);
     expect(check('x^{a+1}')).toMatchInlineSnapshot(`x^(a + 1)`);
@@ -258,7 +258,7 @@ describe('PRECEDENCE', () => {
     expect(check('1+2^3')).toMatchInlineSnapshot(`1 + 2^3`);
     expect(check('(1+2)^3')).toMatchInlineSnapshot(`(1 + 2)^3`);
     expect(check('1^2+3')).toMatchInlineSnapshot(`1 + 3`);
-    expect(check('1^{2+3}')).toMatchInlineSnapshot(`1`);
+    expect(check('1^{2+3}')).toMatchInlineSnapshot(`1^(2 + 3)`);
     expect(check('1+2/3')).toMatchInlineSnapshot(`1 + 2/3`);
     expect(check('(1+2)/3')).toMatchInlineSnapshot(`1/3 * (1 + 2)`);
     expect(check('1/2+3')).toMatchInlineSnapshot(`3 + 1/2`);

--- a/test/compute-engine/latex-syntax/roots.test.ts
+++ b/test/compute-engine/latex-syntax/roots.test.ts
@@ -12,8 +12,10 @@ describe('ROOT FUNCTION', () => {
     expect(parse('\\frac{1}{\\sqrt[3]{x}}')).toMatchInlineSnapshot(
       `["Root", "x", -3]`
     );
+    //↓Because as part of canonicalization of 'Divide' which simplifies '1/x', the denominator is
+    //simplified as part of the call to BoxedFunction.inv(): which in-turn calls .root()
     expect(parse('\\frac{1}{\\sqrt[3]{\\sqrt{x}}}')).toMatchInlineSnapshot(
-      `["Divide", 1, "x"]`
+      `["Root", "x", -6]`
     );
   });
 });

--- a/test/compute-engine/latex-syntax/serialize.test.ts
+++ b/test/compute-engine/latex-syntax/serialize.test.ts
@@ -145,9 +145,11 @@ describe('CUSTOM LATEX SERIALIZING', () => {
       `\\frac{ac}{bd}`
     );
     expect(expr.toLatex({ prettify: false })).toMatchInlineSnapshot(
-      `\\frac{ac}{bd}`
+      `\\frac{a}{b}\\frac{c}{d}`
     );
-  }); // @fixme
+
+    //@todo: remaining cases
+  });
 
   test('Invisible Multiply', () => {
     const expr = ce.parse('2x');

--- a/test/compute-engine/latex-syntax/stefnotch.test.ts
+++ b/test/compute-engine/latex-syntax/stefnotch.test.ts
@@ -32,7 +32,9 @@ describe('STEFNOTCH #10', () => {
   });
 
   test('2/ 1^{\\sin(x)}', () => {
-    expect(parse('1^{\\sin(x)}')).toMatchInlineSnapshot(`1`);
+    expect(parse('1^{\\sin(x)}')).toMatchInlineSnapshot(
+      `["Power", 1, ["Sin", "x"]]`
+    );
   });
 
   test('3/ 3\\text{hello}6', () => {

--- a/test/compute-engine/numbers.test.ts
+++ b/test/compute-engine/numbers.test.ts
@@ -1,5 +1,5 @@
-import { BoxedExpression } from '../../src/compute-engine.ts';
 import { Expression } from '../../src/math-json/types.ts';
+import type { BoxedExpression } from '../../src/compute-engine/global-types.ts';
 import { engine as ce } from '../utils';
 
 describe('BOXING OF NUMBER', () => {
@@ -198,7 +198,7 @@ describe('PROPERTIES OF NUMBERS', () => {
       -1: false
       0: false
       +1: false
-      finite: undefined
+      finite: true
       infinite: false
       nan: false
       even: undefined
@@ -374,7 +374,7 @@ describe('PROPERTIES OF NUMBERS', () => {
       -1: false
       0: false
       +1: false
-      finite: undefined
+      finite: true
       infinite: false
       nan: false
       even: undefined

--- a/test/compute-engine/numbers.test.ts
+++ b/test/compute-engine/numbers.test.ts
@@ -81,10 +81,10 @@ describe('PROPERTIES OF NUMBERS', () => {
       real: false
       rational: false
       integer: false
-      positive (>0): false
-      negative (<0): false
-      nonPositive (<=0): false
-      nonNegative (>=0): false
+      positive (>0): undefined
+      negative (<0): undefined
+      nonPositive (<=0): undefined
+      nonNegative (>=0): undefined
       -1: false
       0: false
       +1: false
@@ -169,10 +169,10 @@ describe('PROPERTIES OF NUMBERS', () => {
       real: false
       rational: false
       integer: false
-      positive (>0): false
-      negative (<0): false
-      nonPositive (<=0): false
-      nonNegative (>=0): false
+      positive (>0): undefined
+      negative (<0): undefined
+      nonPositive (<=0): undefined
+      nonNegative (>=0): undefined
       -1: false
       0: false
       +1: false
@@ -191,10 +191,10 @@ describe('PROPERTIES OF NUMBERS', () => {
       real: false
       rational: false
       integer: false
-      positive (>0): false
-      negative (<0): false
-      nonPositive (<=0): false
-      nonNegative (>=0): false
+      positive (>0): undefined
+      negative (<0): undefined
+      nonPositive (<=0): undefined
+      nonNegative (>=0): undefined
       -1: false
       0: false
       +1: false
@@ -213,10 +213,10 @@ describe('PROPERTIES OF NUMBERS', () => {
       real: false
       rational: false
       integer: false
-      positive (>0): false
-      negative (<0): false
-      nonPositive (<=0): false
-      nonNegative (>=0): false
+      positive (>0): undefined
+      negative (<0): undefined
+      nonPositive (<=0): undefined
+      nonNegative (>=0): undefined
       -1: false
       0: false
       +1: false

--- a/test/compute-engine/numeric-mode.test.ts
+++ b/test/compute-engine/numeric-mode.test.ts
@@ -65,8 +65,7 @@ describe('NUMERIC MODE', () => {
   test(`\\cos(555555^{-1})`, () =>
     expect(check('\\cos(555555^{-1})')).toMatchInlineSnapshot(`
       box       = ["Cos", ["Power", 555555, -1]]
-      canonical = ["Cos", ["Divide", 1, 555555]]
-      simplify  = cos(1/555555)
+      canonical = ["Cos", ["Rational", 1, 555555]]
       eval-auto = 0.99999999999837999676
       eval-mach = 0.99999999999838
     `));


### PR DESCRIPTION
Still more work & tests incoming - which is done but needs verification & review - for CanonicalForms `Multiply`, `Divide` & `Number` (tests). `Power` form most notably up for now: this being the trickiest on

If you review this set of changes, will make any requested changes along with the next/remaining batch of work: this should be next Wed./Thu. evening.

The individual commit messages are good sources of info. WRT changes.

Have a batch of incoming code-comments to make (will do tomorrow) which will likely clarify, and sidestep confusion, and highlight key-points/requests.

Some outstanding queries:
- WRT *symbols* being involved in canonicalization (notably, 'Power'):
  - Only recently came to mind that the `holdUntil` symbol attribute is not accounted for during the check on operand values (which could potentially be symbols): should this be the case?
    - Yet furthermore, if this is to be checked, i.e. that the 'holdUntil' value of a symbol-definition is `never`, then would it not be the case that symbols are substituted with values, before canonicalization, either partial or full, takes place? That being said, it would be the case that accounting for symbol values during application of canonical-forms, is unnecessary, since they would be substituted beforehand anyway (and any existing symbols would therefore have a 'holdUntil' value of 'evaluate', 'N', etc...)
   - With the above in mind, in the case of Power-form, for example, should operations such as `1^x`, where `x` is declared as a constant of value `1`, *ever* take place... ?