### PR TITLE
Fix/test: amendments to #238 (CanonicalForms PR), 'Number' form tests, some arch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### ? ? ?
+
+- More consistency with BoxedSymbol properties causing symbol-binding: e.g.
+  `isFinite` and `isInfinity` cause binding, in a similar way to `isOdd`,
+  `isEven`.
+
 ### Breaking Changes
 
 - The `expr.value` property is now equivalent to `expr.valueOf()`. It was
@@ -7,11 +13,46 @@
   of the expression produced some unexpected results, for example when the
   expression was not pure.
 
+- `BoxedExpr.sgn` now returns _undefined_ for complex numbers, or symbols with a
+  complex-number value.
+
+-
+
 ### New Features and Improvements
 
 - Added a rule to solve the equation `a^x + b = 0`
 - The LaTeX parser now supports the `\placeholder[]{}`, `\phantom{}`,
   `\hphantom{}`, `\vphantom{}`, `\mathstrut`, `\strut` and `\smash{}` commands.
+
+- The range of recognized sign values, i.e. as returned from
+  `BoxedExpression.sgn` has been simplified (e.g. '...-infinity' and 'nan' have
+  been removed)
+
+- The Power canonical-form is less aggressive - only carrying-out ops. as listed
+  in doc. - is much more careful in its consideration of operand types &
+  values... (for example, typically, exponents are required to be _numbers_:
+  e.g. `x^1` will simplify, but `x^y` (where y===0), or `x^{1+0}`, will not)
+
+### Issues Resolved
+
+- Ensure expression LaTeX serialization is based on MathJSON generated with
+  matching 'pretty' formatting (or not), therefore resulting in LaTeX with less
+  prettification, where `prettify == false` (#daef87f)
+
+- Symbols declare with a `constant` flag are now not marked as 'inferred'
+
+- Some BoxedSymbols properties now more consistently return 'undefined', instead
+  of a 'boolean' (i.e. because the symbol is non-bound)
+
+- Some `expr.root()` computations
+
+- Canonical-forms
+  - Fixes the `Number` form
+  - Forms (at least, 'Number', 'Power') do not mistakenly _fully_ canonicalize
+    operands
+  - This (partial canonicalization) now substitutes symbols (constants) with a
+    `holdUntil` value of _never_ during/prior-to canonicalization (i.e. just
+    like for full canonicalization)
 
 ## 0.29.1 _2025-03-31_
 

--- a/src/compute-engine/boxed-expression/box.ts
+++ b/src/compute-engine/boxed-expression/box.ts
@@ -382,7 +382,13 @@ export function box(
     }
 
     if (!isValidIdentifier(expr)) return ce.error('invalid-identifier', expr);
-    return ce.symbol(expr, { canonical });
+    // Let 'partial' canonicalization fetch the canonical variant of symbols: in order that at
+    // minimum, they may be substituted with associated definition values (when its def. 'holdUntil'
+    // is 'never')
+    // @note: alternatively, this could be signalled by a 'Symbol' CanonicalForm: but this way is
+    // more predicatable, & ensures substitution as per above
+    const canonicalSymbol = canonical || options.canonical !== false;
+    return ce.symbol(expr, { canonical: canonicalSymbol });
   }
 
   //

--- a/src/compute-engine/boxed-expression/boxed-function.ts
+++ b/src/compute-engine/boxed-expression/boxed-function.ts
@@ -681,7 +681,7 @@ export class BoxedFunction extends _BoxedExpression {
     }
 
     // root(sqrt(a), c) -> root(a, 2*c)
-    if (this.operator === 'Sqrt' || this.operator === 'Root') {
+    if (this.operator === 'Sqrt') {
       if (e !== undefined) return this.op1.root(e * 2);
       if (typeof exp !== 'number') return this.op1.root(exp.mul(2));
     }

--- a/src/compute-engine/boxed-expression/boxed-symbol-definition.ts
+++ b/src/compute-engine/boxed-expression/boxed-symbol-definition.ts
@@ -110,7 +110,6 @@ export class _BoxedSymbolDefinition implements BoxedSymbolDefinition {
     return this.constant;
   }
 
-  /** The symbol was previously inferred, but now it has a declaration. Update the def accordingly (we can't replace defs, as other expressions may be referencing them) */
   update(def: SymbolDefinition): void {
     if (def.wikidata) this.wikidata = def.wikidata;
     if (def.description) this.description = def.description;

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -451,7 +451,9 @@ export interface BoxedExpression {
    *
    * A symbol has a `"Symbol"` operator.
    *
-   * A number has a `"Number"`, `"Real"`, `"Rational"` or `"Integer"` operator.
+   * A number has a `"Number"`, `"Real"`, `"Rational"` or `"Integer"` operator; amongst some others.
+   * Practically speaking, for fully canonical and valid expressions, all of these are likely to
+   * collapse to `"Number"`.
    *
    */
   readonly operator: string;

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -743,11 +743,22 @@ export interface BoxedExpression {
   readonly isFinite: boolean | undefined;
 
   /**
+   * If this is a Number or Symbol with a numeric value, and the numeric value is an **integer**,
+   * return a `boolean`. For all other cases, return *undefined*.
+   *
+   * Since this necessitates consultation to this expression's value, triggers *binding* for
+   * symbols.
+   *
    * @category Numeric Expression
    */
   readonly isEven: boolean | undefined;
 
   /**
+   * If this is a Number or Symbol with a numeric value, and the numeric value is an **integer**,
+   * return a `boolean`. For all other cases, return *undefined*.
+   *
+   * *Note* that this triggers *binding* for symbols.
+   *
    * @category Numeric Expression
    */
   readonly isOdd: boolean | undefined;

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -525,16 +525,19 @@ export interface BoxedExpression {
    */
   readonly op3: BoxedExpression;
 
-  /** If true, the value of the expression never changes and evaluating it has
-   * no side-effects.
+  /** If *true*, the value of the expression never changes (provided the state of the engine does not
+   * change), and evaluating it has no side-effects.
    *
-   * If false, the value of the expression may change, if the
-   * value of other expression changes or for other reasons.
-   *
-   * If `this.isPure` is `false`, `this.value` is undefined. Call
-   * `this.evaluate()` (or '*this.N()*') to determine the value of the expression instead.
+   * If *false*, the value of the expression may differ for each request to it (see `evaluate()` or `N().valueOf()`).
    *
    * As an example, the `Random` function is not pure.
+   *
+   * A requirement for the definition of a pure function is that all of its arguments are pure too.
+   * Said differently, if this is a function, it must be a pure function *expression*, too.
+   *
+   * This expression being pure (and a function) does not guarantee that the returned value will be
+   * the same every time (i.e. that it is constant). To guarantee this, also check that `isConstant
+   * === true`.
    *
    * :::info[Note]
    * Applicable to canonical and non-canonical expressions.
@@ -553,7 +556,7 @@ export interface BoxedExpression {
    * - `2` is constant
    * - `Pi` is constant
    * - `["Add", "Pi", 2]` is constant
-   * - `x` is inconstant: unless declared with a constant value.
+   * - `x` is inconstant: unless declared with a constant flag.
    * - `["Add", "x", 2]` is either constant or inconstant, depending on whether `x` is constant.
    */
   readonly isConstant: boolean;
@@ -1136,23 +1139,18 @@ export interface BoxedExpression {
   /**
    * Return the value of the canonical form of this expression.
    *
-   * A pure expression always return the same value and has no side effects.
+   * A pure expression always returns the same value (provided that it remains constant / values of
+   * sub-expressions or symbols do not change), and has no side effects.
    * If `expr.isPure` is `true`, `expr.value` and `expr.evaluate()` are
    * synonyms.
    *
-   * For an impure expression, `expr.value` is undefined.
-   *
-   * Evaluating an impure expression may have some side effects, for
-   * example modifying the `ComputeEngine` environment, such as its set of
-   * assumptions.
-   *
-   * The result may be a rational number or the product of a rational number
-   * and the square root of an integer.
+   * Evaluating an impure expression may return a varying value, and may have some side effects such
+   * adjusting symbol assumptions.
    *
    * To perform approximate calculations, use `expr.N()` instead,
-   * or set `options.numericApproximation` to `true`.
+   * or call with `options.numericApproximation` to `true`.
    *
-   * The result of `expr.evaluate()` may be the same as `expr.simplify()`.
+   * It is possible that the result of `expr.evaluate()` may be the same as `expr.simplify()`.
    *
    * The result is in canonical form.
    *
@@ -1232,6 +1230,12 @@ export interface BoxedExpression {
    * representing the value of this expression.
    *
    * Otherwise, return `undefined`.
+   *
+   * :::info[Note]
+   * The expression's value may depend on the current state of the engine. For instance, if a
+   * non-constant symbol, the value is subject to change via value assignments and assumptions about
+   * its value. Also, for both numbers and symbols: the *representation* of the value may depend on
+   * the current engine precision.
    *
    */
   get value(): number | boolean | string | undefined;

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -579,6 +579,13 @@ export interface BoxedExpression {
    * If this expression is already canonical, the value of canonical is
    * `this`.
    *
+   * :::info[Note]
+   * 'Partially' canonical expressions, such as those produced through `CanonicalForm`, also yield
+   * an expression which is marked as 'canonical'. This means that, likewise for partially canonical
+   * expressions, the `canonical` property will return the self-same expression (& 'isCanonical'
+   * will also be true).
+   * :::
+   *
    */
   get canonical(): BoxedExpression;
 

--- a/src/compute-engine/index.ts
+++ b/src/compute-engine/index.ts
@@ -430,7 +430,7 @@ export class ComputeEngine implements IComputeEngine {
       im: Infinity,
     });
 
-    // Reset the caches/create numeric constants
+    // Reset the caches/create (precision-dependent) numeric constants
     this.reset();
 
     //
@@ -1270,7 +1270,7 @@ export class ComputeEngine implements IComputeEngine {
    * if the type is not known yet. If `unknown`, the type will be inferred
    * based on usage.
    *
-   * An identifier can be redeclared with a different type, but only if
+   * An identifier *can be redeclared* with a different type, but only if
    * the type of the identifier was inferred. If the domain was explicitly
    * set, the identifier cannot be redeclared.
    *

--- a/test/compute-engine/calculus.test.ts
+++ b/test/compute-engine/calculus.test.ts
@@ -1,4 +1,4 @@
-import type { BoxedExpression } from '../../src/compute-engine/types';
+import type { BoxedExpression } from '../../src/compute-engine/global-types';
 import { engine } from '../utils';
 
 function parse(expr: string): BoxedExpression {

--- a/test/compute-engine/canonical-form.test.ts
+++ b/test/compute-engine/canonical-form.test.ts
@@ -665,6 +665,44 @@ describe('CANONICAL FORMS', () => {
         canonical  = ["Root", ["Multiply", ["Rational", 1, 3], "a"], 3]
       `);
     });
+
+    test(`(a^b)^c -> a^(b*c)`, () => {
+      // expect(checkPower('')).toMatchInlineSnapshot();
+      expect(checkPower('{a^3}^4')).toMatchInlineSnapshot(`
+        box        = ["Power", ["Power", "a", 3], 4]
+        canonForms = ["Power", "a", ["Multiply", 3, 4]]
+        canonical  = ["Power", "a", ["Multiply", 3, 4]]
+      `);
+      //note: 'Multiply' args. are ordered in the output JSON: but the result 'Power'
+      //BoxedExpression still has (ordered) operands [b, c].
+      expect(checkPower('{a^{{b^2}^e}}^{0.5*\\pi}')).toMatchInlineSnapshot(`
+        box        = [
+          "Power",
+          ["Power", "a", ["Power", ["Square", "b"], "e"]],
+          ["Multiply", 0.5, "Pi"]
+        ]
+        canonForms = [
+          "Power",
+          "a",
+          [
+            "Multiply",
+            0.5,
+            "Pi",
+            ["Power", "b", ["Multiply", 2, "ExponentialE"]]
+          ]
+        ]
+        canonical  = [
+          "Power",
+          "a",
+          [
+            "Multiply",
+            0.5,
+            "Pi",
+            ["Power", "b", ["Multiply", 2, "ExponentialE"]]
+          ]
+        ]
+      `);
+    });
   });
 
   describe('Number', () => {


### PR DESCRIPTION
Only a smaller one this time

But a few key points/queries which will be highlighted in comments:

- Not sure if, as part of the planned re-arch. of canonicalization, that these `CanonicalForm` *functions* will remain (i.e. as function-based replacement rules), or be replaced by individual, string-based rules. Of note though, is that the thus-far published forms should be useful guidance in achieving this, & should reduce the workload substantially.
  (In some cases though, I have pondered how/if string-based replacement rules could achieve this (so easily): considering the substantial set of conditions required upon some operations.
  I.e. you could imagine: `x_{type:number;!isFunctionExpression;...}^0  ->  1`, or `a_{AnyInfinity}^b_{type:complex; real > 0}  ->  ComplexInfinity`, to be verbose...)

- Have wondered, with regards to the discussion https://github.com/cortex-js/compute-engine/pull/238#discussion_r2034335185, particularly `The value of symbols should not be considered during canonicalization, even constant ones...`:
  - Is it the case that this should be amended slightly to `The value of *non-canonical/bound* symbols...`. Because, as will be remarked in the upcoming review, `Pi`, for example, being a library-defined ID., appears to typically be 'always' bound/canonical: such that, unlike the case for user-defined/non-default library constants (which as stated should _not_ be bound at canonicalization), it seems reasonable that `Pi^0`, `-Pi^Infinity`, etc. *should* apply?

- Believe that there is a current bug for SymbolDefinitions.
  It appears that, `holdUntil` being set to `never` should only be permitted when the *constant* switch is also `true`.
  Otherwise, these non-constant symbols get substituted at canonicalization, resulting in inconsistent/variable full canonical-form?


It should be 1-2 weeks until I can finish-up the final/remaining forms PR (at least to the same degree of attention as here), but that will come.

In the next post, I will leave some open questions that have popped-up throughout my completing this request & again having stumbled into many things. (Most of which related to what's going on here).