### PR TITLE
Patterns substitution fixes

### DIFF
--- a/src/api.md
+++ b/src/api.md
@@ -1,4 +1,4 @@
-
+# 01
 
 ## Compute Engine
 
@@ -1273,6 +1273,10 @@ is canonical.
 
 :::info[Note]
 Applicable to canonical and non-canonical expressions.
+
+If this is a function, an empty substitution is given, and the computed value of `canonical`
+does not differ from that of this expr.: then a call this method is analagous to requesting a
+*clone*.
 :::
 
 ####### sub
@@ -1344,11 +1348,24 @@ Transform the expression by applying one or more replacement rules:
 
 See also `expr.subs()` for a simple substitution of symbols.
 
-If `options.canonical` is not set, the result is canonical if `this`
-is canonical.
+Procedure for the determining the canonical-status of the input expression and replacements:
+
+- If `options.canonical` is set, the *entire expr.* is canonicalized to this degree: whether
+the replacement occurs at the top-level, or within/recursively.
+
+- If otherwise, the *direct replacement will be canonical* if either the 'replaced' expression
+is canonical, or the given replacement (- is a BoxedExpression and -) is canonical.
+Notably also, if this replacement takes place recursively (not at the top-level), then exprs.
+containing the replaced expr. will still however have their (previous) canonical-status
+*preserved*... unless this expr. was previously non-canonical, and *replacements have resulted
+in canonical operands*. In this case, an expr. meeting this criteria will be updated to
+canonical status. (Canonicalization is opportunistic here, in other words).
 
 :::info[Note]
 Applicable to canonical and non-canonical expressions.
+
+To specify a match for single symbol (non wildcard), it must be boxed (e.g. `{ match:
+ce.box('x'), ... }`), but it is suggested to use method *'subs()'* for this.
 :::
 
 ####### rules
@@ -2647,9 +2664,9 @@ type PatternMatchOptions = {
 
 Control how a pattern is matched to an expression.
 
-- `substitution`: if present, assumes these values for the named wildcards,
-   and ensure that subsequent occurrence of the same wildcard have the same
-   value.
+- `substitution`: if present, assumes these values for a subset of
+   named wildcards, and ensure that subsequent occurrence of the same
+   wildcard have the same value.
 - `recursive`: if true, match recursively, otherwise match only the top
    level.
 - `useVariations`: if false, only match expressions that are structurally identical.
@@ -2784,18 +2801,22 @@ type Rule =
 };
 ```
 
-A rule describes how to modify an expressions that matches a pattern `match`
+A rule describes how to modify an expression that matches a pattern `match`
 into a new expression `replace`.
 
 - `x-1` \( \to \) `1-x`
 - `(x+1)(x-1)` \( \to \) `x^2-1
 
-The patterns can be expressed as LaTeX strings or a MathJSON expressions.
+The patterns can be expressed as LaTeX strings or `SemiBoxedExpression`'s.
+Alternatively, match/replace logic may be specified by a `RuleFunction`, allowing both custom
+logic/conditions for the match, and either a *BoxedExpression* (or `RuleStep` if being
+descriptive) for the replacement.
 
 As a shortcut, a rule can be defined as a LaTeX string: `x-1 -> 1-x`.
 The expression to the left of `->` is the `match` and the expression to the
 right is the `replace`. When using LaTeX strings, single character variables
-are assumed to be wildcards.
+are assumed to be wildcards. The rule LHS ('match') and RHS ('replace') may also be supplied
+separately: in this case following the same rules.
 
 When using MathJSON expressions, anonymous wildcards (`_`) will match any
 expression. Named wildcards (`_x`, `_a`, etc...) will match any expression
@@ -8042,7 +8063,7 @@ valueOf(): string
 
 </MemberCard>
 
-
+# 02
 
 ## MathJSON
 
@@ -8213,7 +8234,7 @@ The dictionary and function nodes can contain expressions themselves.
 
 </MemberCard>
 
-
+# 03
 
 ## Type
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,11 +1,39 @@
-export function permutations<T>(
-  xs: ReadonlyArray<T>
+/**
+ *
+ * <!--
+ * !@consider?
+ * - In terms of BoxedExpressions - optimizations which are always desirable to take place are
+ * possible...
+ *  ^Perhaps then, a wrapper BoxedExpr. utility for specifying these permutations via 'condition'
+ *  would be apt...?
+ *
+ * - ^If wishing to take adv. of this, the 'condition' callback would likely benefit from a second parameter typed as a collection
+ * ('Set' if enforcing unique) with all hitherto (arbitrary representations) of generated
+ * permutations.
+ *  (See commented snippets within function signature below.)
+ * -->
+ *
+ * @export
+ * @template T
+ * @param xs
+ * @param [condition]
+ * @returns
+ */
+export function permutations<T /* , Y extends any = any */>(
+  xs: ReadonlyArray<T>,
+  condition?: (
+    xs: ReadonlyArray<T> /* , generated: Set<Y> | Set<[Y,T]>? */
+  ) => boolean
+  // cacheKey?: (T) => Y
 ): ReadonlyArray<ReadonlyArray<T>> {
   const result: ReadonlyArray<T>[] = [];
 
-  const permute = (arr, m = []) => {
+  const permute = (arr: T[], m: T[] = []) => {
     if (arr.length === 0) {
-      result.push(m);
+      if (!condition || condition(m)) {
+        // Use spread operator to create a shallow copy of m
+        result.push([...m]);
+      }
     } else {
       for (let i = 0; i < arr.length; i++) {
         const curr = arr.slice();
@@ -15,7 +43,8 @@ export function permutations<T>(
     }
   };
 
-  permute(xs);
+  //@fix: (typing)
+  permute(xs as T[]);
 
   return result;
 }

--- a/src/compute-engine/boxed-expression/boxed-patterns.ts
+++ b/src/compute-engine/boxed-expression/boxed-patterns.ts
@@ -11,6 +11,14 @@ export function isWildcard(expr: BoxedExpression): expr is BoxedSymbol {
   );
 }
 
+/**
+ * Return the string representing this wildcard, including any optional (one-character) name, or
+ * `null` if not a wildcard expression.
+ *
+ * @export
+ * @param expr
+ * @returns
+ */
 export function wildcardName(expr: BoxedExpression): string | null {
   if (expr.symbol?.startsWith('_')) return expr.symbol;
 
@@ -31,7 +39,9 @@ export function wildcardName(expr: BoxedExpression): string | null {
 /**
  *
  * <!--
- * @todo: Utilize (e.g. ./match.ts)
+ * @todo:
+ * - Utilize moreso (e.g. ./match.ts)
+ * - 'Wildcard' -> 'Universal', for clarity...?
  * -->
  *
  * @export

--- a/src/compute-engine/boxed-expression/boxed-patterns.ts
+++ b/src/compute-engine/boxed-expression/boxed-patterns.ts
@@ -27,3 +27,44 @@ export function wildcardName(expr: BoxedExpression): string | null {
 
   return null;
 }
+
+/**
+ *
+ * <!--
+ * @todo: Utilize (e.g. ./match.ts)
+ * -->
+ *
+ * @export
+ * @param expr
+ * @returns
+ */
+export function wildcardType(
+  expr: BoxedExpression | string
+): 'Wildcard' | 'Sequence' | 'OptionalSequence' | null {
+
+  if (typeof expr === 'string') {
+    if (expr.startsWith('_')) {
+      if (expr.startsWith('__')) {
+        if (expr.startsWith('___')) return 'Sequence';
+        return 'OptionalSequence';
+      }
+      return 'Wildcard';
+    }
+    return null;
+  }
+
+  if (expr.symbol !== null) {
+    const symbol = expr.symbol!;
+    if (!symbol.startsWith('_')) return null;
+    if (!symbol.startsWith('__')) return 'Wildcard';
+    return symbol.startsWith('___') ? 'OptionalSequence' : 'Sequence';
+  }
+
+  if (expr.isFunctionExpression) {
+    if (expr.operator === 'Wildcard') return 'Wildcard';
+    if (expr.operator === 'WildcardSequence') return 'Sequence';
+    if (expr.operator === 'WildcardOptionalSequence') return 'OptionalSequence';
+  }
+
+  return null;
+}

--- a/src/compute-engine/boxed-expression/rules.ts
+++ b/src/compute-engine/boxed-expression/rules.ts
@@ -419,7 +419,7 @@ function parseRule(
 
         // Check for conditions
         const conditions = parseModifierExpression(parser);
-        if (conditions === null) return null;
+        if (conditions === null) return `${prefix}${id}`;
 
         if (!wildcardConditions[id]) wildcardConditions[id] = conditions;
         else wildcardConditions[id] += ',' + conditions;

--- a/src/compute-engine/boxed-expression/rules.ts
+++ b/src/compute-engine/boxed-expression/rules.ts
@@ -703,6 +703,8 @@ export function applyRule(
       return subExpr.value;
     });
 
+    // At least one operand (directly or recursively) matched: but continue onwards to match against
+    // the top-level expr., test against any 'condition', et cetera.
     if (operandsMatched)
       expr = expr.engine.function(expr.operator, newOps, { canonical });
   }
@@ -728,7 +730,7 @@ export function applyRule(
   onBeforeMatch?.(rule, expr);
 
   const sub = match
-    ? expr.match(match, { substitution, ...options, useVariations })
+    ? expr.match(match, { substitution, useVariations, recursive: false })
     : {};
 
   // If the `expr` does not match the pattern, the rule doesn't apply
@@ -762,6 +764,7 @@ export function applyRule(
     }
   }
 
+  //@note: '.subs()' acts like an expr. 'clone' here (in case of an empty substitution)
   const result =
     typeof replace === 'function'
       ? replace(expr, sub)

--- a/src/compute-engine/boxed-expression/validate.ts
+++ b/src/compute-engine/boxed-expression/validate.ts
@@ -225,6 +225,15 @@ export function checkPure(
  *
  * Otherwise return a list of expressions indicating the mismatched
  * arguments.
+ * 
+ * <!--
+ * @todo?:
+ * - Some permutations of operands should perhaps always be treated as invalid. Consider:
+ *   - A sequence wildcard (non-optional, i.e. '__') followed by either a universal wildcard ('_'),
+ *   or another non-optional sequence wildcard. (note that an optional sequence wildcard is
+ *   unproblematic here.)
+ * 
+ * -->
  *
  */
 export function validateArguments(

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -1063,6 +1063,10 @@ export interface BoxedExpression {
    *
    * :::info[Note]
    * Applicable to canonical and non-canonical expressions.
+   * 
+   * If this is a function, an empty substitution is given, and the computed value of `canonical`
+   * does not differ from that of this expr.: then a call this method is analagous to requesting a
+   * *clone*.
    * :::
    *
    */

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -1063,7 +1063,7 @@ export interface BoxedExpression {
    *
    * :::info[Note]
    * Applicable to canonical and non-canonical expressions.
-   * 
+   *
    * If this is a function, an empty substitution is given, and the computed value of `canonical`
    * does not differ from that of this expr.: then a call this method is analagous to requesting a
    * *clone*.
@@ -1107,8 +1107,18 @@ export interface BoxedExpression {
    *
    * See also `expr.subs()` for a simple substitution of symbols.
    *
-   * If `options.canonical` is not set, the result is canonical if `this`
-   * is canonical.
+   * Procedure for the determining the canonical-status of the input expression and replacements:
+   *
+   * - If `options.canonical` is set, the *entire expr.* is canonicalized to this degree: whether
+   * the replacement occurs at the top-level, or within/recursively.
+   *
+   * - If otherwise, the *direct replacement will be canonical* if either the 'replaced' expression
+   * is canonical, or the given replacement (- is a BoxedExpression and -) is canonical.
+   * Notably also, if this replacement takes place recursively (not at the top-level), then exprs.
+   * containing the replaced expr. will still however have their (previous) canonical-status
+   * *preserved*... unless this expr. was previously non-canonical, and *replacements have resulted
+   * in canonical operands*. In this case, an expr. meeting this criteria will be updated to
+   * canonical status. (Canonicalization is opportunistic here, in other words).
    *
    * :::info[Note]
    * Applicable to canonical and non-canonical expressions.

--- a/src/compute-engine/global-types.ts
+++ b/src/compute-engine/global-types.ts
@@ -1122,6 +1122,9 @@ export interface BoxedExpression {
    *
    * :::info[Note]
    * Applicable to canonical and non-canonical expressions.
+   * 
+   * To specify a match for single symbol (non wildcard), it must be boxed (e.g. `{ match:
+   * ce.box('x'), ... }`), but it is suggested to use method *'subs()'* for this.
    * :::
    */
   replace(
@@ -1929,9 +1932,9 @@ export type JsonSerializationOptions = {
 /**
  * Control how a pattern is matched to an expression.
  *
- * - `substitution`: if present, assumes these values for the named wildcards,
- *    and ensure that subsequent occurrence of the same wildcard have the same
- *    value.
+ * - `substitution`: if present, assumes these values for a subset of
+ *    named wildcards, and ensure that subsequent occurrence of the same
+ *    wildcard have the same value.
  * - `recursive`: if true, match recursively, otherwise match only the top
  *    level.
  * - `useVariations`: if false, only match expressions that are structurally identical.
@@ -2953,18 +2956,22 @@ export type RuleStep = {
 export type RuleSteps = RuleStep[];
 
 /**
- * A rule describes how to modify an expressions that matches a pattern `match`
+ * A rule describes how to modify an expression that matches a pattern `match`
  * into a new expression `replace`.
  *
  * - `x-1` \( \to \) `1-x`
  * - `(x+1)(x-1)` \( \to \) `x^2-1
  *
- * The patterns can be expressed as LaTeX strings or a MathJSON expressions.
+ * The patterns can be expressed as LaTeX strings or `SemiBoxedExpression`'s.
+ * Alternatively, match/replace logic may be specified by a `RuleFunction`, allowing both custom
+ * logic/conditions for the match, and either a *BoxedExpression* (or `RuleStep` if being
+ * descriptive) for the replacement.
  *
  * As a shortcut, a rule can be defined as a LaTeX string: `x-1 -> 1-x`.
  * The expression to the left of `->` is the `match` and the expression to the
  * right is the `replace`. When using LaTeX strings, single character variables
- * are assumed to be wildcards.
+ * are assumed to be wildcards. The rule LHS ('match') and RHS ('replace') may also be supplied
+ * separately: in this case following the same rules.
  *
  * When using MathJSON expressions, anonymous wildcards (`_`) will match any
  * expression. Named wildcards (`_x`, `_a`, etc...) will match any expression


### PR DESCRIPTION
Sorry that this is later than expected... At least, it's a substantial contribution with some good fixes.

Like usual, will do an inline/source-code review on most outstanding (in literal sense) changes.

There are still one or two remaining issues on the subject of pattern matching (notably, often referenced in source-code comments. Therefore, these likely best reviewed after scanning over changes):


- Using permutations on *patterns* (only) does not, with current behaviour, capture, some cases of commutative-operator operand sequences where it would otherwise be expected.
 A simple case is (extracted from inline doc.) is `['Add', 1, 2, 3, 'x', 5]` matched against pattern `['Add', 1, '__a']`. This does not match (neither prior to, or after changes added here), due to the match being made against the canonicalized input (`['Add', 'x', 1, 2, 3, 4, 5]` (I think).
- This one may more-so just be due to outdated (public) documentation:
Specifying symbols as *strings* for match/replace - via `expr.replace()` - as illustrated within the `Patterns and Rules` guide, does not function *as expected* (i.e. as documentation suggests), due to the 'match' part being parsed as a rule-string: that is, in which symbols (single-character) are parsed as wildcards. 
I.e. the example given listed on this page does not function as indicated, but each rule instead matches/replaces _any_ expression:
```typescript
const expr = ce.box(["Add", ["Multiply", "a", "x"], "b"]);
expr.replace([
    { match: "a", replace: 2 },
    { match: "b", replace: 3 }
  ],
  { recursive: true }
)?.print();
```

And some general notes (again best seen after visiting changes):
- Match permutations (i.e. for commutative expr. operators) could benefit from further optimization.
- (Was going to add this as a final commit, & would not take me much time to add):
  'Pattern' validation ideally to be carried out upon calls to `expr.match()`: such that sequences of (adjacent) regular-sequence wildcards (consider `['List', '__a', '__b', ...]`) are considered 'invalid' (a bit too strong a term).
 In reference to changes: generated permutations skip patterns of this structure, on the basis of these being *redundant* (if not, unpredictable).
 There is the question also, of what the return value should be (of `expr.match()`); `null` does not seem quite fitting. Perhaps something like a 'reason', as returned from `ce.ask()` ...?

And a few future suggestions & *feature requests*:

- Personally, would find it useful to have a `matchPermutations` option (i.e. as applicable to commutative FN's), for `expr.match()`. Sometimes, particularly when wildcards are included in a pattern, I would find desirable to only match exactly as is/as requested.

- Also for *expr.match()*, it would have utility to be able to specify expression-scoped / pertinent *conditions* in a similar way as can be expressed via replacement-rule LaTeX match strings (`x_{numeric} + y_{prime}` for instance.).
  Being able to specify LaTeX-style 'match' strings in the same manner of method 'replace', would not go amiss either...

- For method `replace()`:
  - Arguably, `recursive: true`  should be *default*...? (personal preference/use is for this to be so. Semantically, the sense I get/interpret is 'replace all instances (of)'. Mentionably also, without 'recursive: true', a successful result is nothing but a (top-level) expression re-assignment (assuming assignment of call result) at the Javascript/Typescript level).
  - A way/a syntax variant to *match single-character variables as symbols* (instead of wildcards) in LaTeX strings would be desirable? Could not find a way to do this (but this is of course easily expressible with _boxed_-expressions.
    A possible means could be to use latex ID-prefixes (`\operatorname`, `\mathrm`...), but clearly this would be long-winded. Perhaps alternatively a special minor, syntactical rule to specify this (same level of simplicity as the use of prefix `...` to match sequences, for instance).

 Bit heavy on the text there, but for future reference...!