### PR TITLE
fix: convert small numbers to exact rationals in division ops when possible

### DIFF
--- a/test/compute-engine/latex-syntax/numbers.test.ts
+++ b/test/compute-engine/latex-syntax/numbers.test.ts
@@ -262,6 +262,11 @@ describe('PARSING OF NUMBER', () => {
       `{num: "9007199254741033"}`
     );
   });
+
+  test('Division with small ints', () => {
+    expect(ce.parse('3 / 3e-2').evaluate().json).toEqual(100);
+    expect(ce.parse('3 / 0.03').evaluate().json).toEqual(100);
+  });
 });
 
 describe('SERIALIZATION OF NUMBERS', () => {


### PR DESCRIPTION
Closes #269 . This fix was written by Claude 4.5 Opus. When trying to divide, it checks if the decimal has a negative exponent. A heuristic is used for `e <= 15` to try and convert this to an exact rational, e.g.

```
1 / 0.000000000000001  -->  exact rational 10¹⁵/1
1 / 0.0000000000000001  --> approximate decimal (existing code)
```

A test is included -- on master, `3 / 0.03` does not yield 100.