### PR TITLE
Add workflow for publishing to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build production
+        run: npm run build prod
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/BUILD.md
+++ b/BUILD.md
@@ -15,3 +15,25 @@ After cloning the repo:
 | `build prod`      | Make a production build in `/dist`                                         |
 | `test [coverage]` | Run all the tests and generate code coverage data in `/coverage` directory |
 | `test snapshot`   | Update the test snapshots                                                  |
+
+## Releasing to npm
+
+This project uses GitHub Actions to automatically publish to npm when a release
+is created.
+
+### Publishing a new version
+
+1. Update the version in `package.json`
+2. Commit the version change: `git commit -am "Bump version to x.y.z"`
+3. Push to main: `git push origin main`
+4. Create a GitHub release:
+   - Go to your repository → Releases → "Create a new release"
+   - Create a new tag matching the version (e.g., `v0.30.3`)
+   - Fill in the release title and notes
+   - Click "Publish release"
+
+The workflow will automatically:
+
+- Run all tests
+- Build the production bundle
+- Publish to npm


### PR DESCRIPTION
### Setup (one-time)

1. Create an npm access token:
   - Go to [npmjs.com](https://www.npmjs.com/) → Account Settings → Access Tokens
   - Generate a new **Granular Access Token** with publish permissions for `@cortex-js/compute-engine`
   - Alternatively, use a **Classic Automation Token** if you prefer

2. Add the token to GitHub:
   - Go to your repository → Settings → Secrets and variables → Actions
   - Create a new repository secret named `NPM_TOKEN`
   - Paste your npm access token as the value
   
### Publishing a new version

1. Update the version in `package.json`
2. Commit the version change: `git commit -am "Bump version to x.y.z"`
3. Push to main: `git push origin main`
4. Create a GitHub release:
   - Go to your repository → Releases → "Create a new release"
   - Create a new tag matching the version (e.g., `v0.30.3`)
   - Fill in the release title and notes
   - Click "Publish release"