### PR TITLE
fix: implement extraneous root filtering for sqrt equations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Extraneous Root Filtering for Sqrt Equations**: Fixed an issue where solving
+  square root equations could return extraneous roots. When solving equations
+  like `√x = x - 2` or `√x - x + 2 = 0` using the quadratic substitution method
+  (u = √x → solve for u → x = u²), the solver could return roots that satisfy
+  the transformed equation but not the original. The `validateRoots()` function
+  now correctly validates candidate solutions against the original expression
+  before any algebraic transformations (clearing denominators, harmonization),
+  properly filtering out extraneous roots.
+
+  Examples of equations that now correctly filter extraneous roots:
+  - `√x = x - 2` → returns `[4]` (filters out x=1)
+  - `√x + x - 2 = 0` → returns `[1]` (filters out x=4)
+  - `√x - x + 2 = 0` → returns `[4]` (filters out x=1)
+  - `x - 2√x - 3 = 0` → returns `[9]` (filters out x=1)
+  - `2x + 3√x - 2 = 0` → returns `[1/4]` (filters out x=4)
+
 ### New Features
 
 #### Subscripts and Indexing

--- a/requirements/TODO.md
+++ b/requirements/TODO.md
@@ -400,50 +400,9 @@ alternatives.
 
 ## Equation Solving Enhancements
 
-### 14. Extraneous Root Filtering for Sqrt Equations
+### ~~14. Extraneous Root Filtering for Sqrt Equations~~ ✅ COMPLETED
 
-**Problem:** The sqrt equation solver uses quadratic substitution (u = √x, solve
-au² + bu + c = 0, then x = u²). This can produce extraneous roots that don't
-satisfy the original equation.
-
-**Example:**
-
-```
-x - 4√x + 3 = 0
-Substitution: u² - 4u + 3 = 0 → u = 1, 3
-Back-substitute: x = 1, 9
-Verify: 1 - 4(1) + 3 = 0 ✓, 9 - 4(3) + 3 = 0 ✓ (both valid in this case)
-
-But for x + 2√x + 3 = 0:
-u² + 2u + 3 = 0 → u = -1 ± √2i (complex)
-x = u² might give real values that don't satisfy original
-```
-
-**Current behavior:** Returns both roots from the quadratic formula without
-validation.
-
-**Solution:** Add a verification step in `validateRoots()` that:
-
-1. Substitutes each candidate solution back into the original equation
-2. Checks if it evaluates to 0 (within tolerance)
-3. Filters out solutions that don't satisfy
-
-**Implementation location:** The existing `validateRoots()` function in
-`solve.ts` already does this, but it's called with the wrong expression. Need to
-ensure the original (pre-harmonization) expression is used for validation.
-
-**Test case to add:**
-
-```typescript
-// Should return [1] not [1, 9] if 9 is extraneous
-test('should filter extraneous sqrt roots', () => {
-  const e = expr('\\sqrt{x} - x + 2 = 0');  // Only x=1 is valid
-  const result = e.solve('x');
-  // Verify each solution satisfies the original equation
-});
-```
-
-**File:** `src/compute-engine/boxed-expression/solve.ts`
+See `requirements/DONE.md` for implementation details.
 
 ---
 

--- a/src/compute-engine/boxed-expression/solve.ts
+++ b/src/compute-engine/boxed-expression/solve.ts
@@ -638,6 +638,13 @@ export function findUnivariateRoots(
     expr = expr.op1.expand().sub(expr.op2.expand()).simplify();
   else expr = expr.expand().simplify();
 
+  // Save the expression BEFORE clearing denominators and other transformations.
+  // This is crucial for validating roots: clearing denominators and harmonization
+  // can introduce extraneous roots that satisfy the transformed equation but not
+  // the original. For example, sqrt equations using quadratic substitution
+  // (u = √x → au² + bu + c = 0 → x = u²) may produce extraneous roots.
+  const originalExpr = expr;
+
   // Clear denominators to enable matching of expressions like F - 3x/h = 0
   expr = clearDenominators(expr);
 
@@ -702,9 +709,11 @@ export function findUnivariateRoots(
 
   ce.popScope(); // End lexical scope for the unknown
 
-  // Validate the roots
+  // Validate the roots against the ORIGINAL expression (before clearing
+  // denominators and harmonization). This filters out extraneous roots that
+  // may have been introduced by algebraic transformations.
   return validateRoots(
-    expr,
+    originalExpr,
     x,
     result.map((x) => x.evaluate().simplify())
   );

--- a/test/compute-engine/solve.test.ts
+++ b/test/compute-engine/solve.test.ts
@@ -320,6 +320,83 @@ describe('SOLVING SQRT AND LN EQUATIONS', () => {
   });
 });
 
+// Tests for extraneous root filtering in sqrt equations (Task #14)
+// Sqrt equations using quadratic substitution (u = √x → solve for u → x = u²)
+// can produce extraneous roots that must be filtered out.
+describe('EXTRANEOUS ROOT FILTERING FOR SQRT EQUATIONS', () => {
+  // √x = x - 2 has candidate solutions x=1 and x=4, but x=1 is extraneous
+  // Derivation: √x = x - 2 → x = (x-2)² → x = x² - 4x + 4 → x² - 5x + 4 = 0
+  // → (x-1)(x-4) = 0 → x = 1, 4
+  // Verify: x=1: √1 = 1, 1-2 = -1, 1 ≠ -1 ❌ (extraneous)
+  // Verify: x=4: √4 = 2, 4-2 = 2, 2 = 2 ✓
+  test('should filter extraneous root for sqrt(x) = x - 2', () => {
+    const e = expr('\\sqrt{x} = x - 2');
+    const result = e.solve('x')?.map((x) => x.json);
+    expect(result).toEqual([4]);
+  });
+
+  // √x + x - 2 = 0 has candidate solutions from x + √x - 2 = 0
+  // u² + u - 2 = 0 → (u+2)(u-1) = 0 → u = -2 or u = 1
+  // x = u² → x = 4 or x = 1
+  // Verify: x=4: √4 + 4 - 2 = 2 + 4 - 2 = 4 ≠ 0 ❌ (extraneous)
+  // Verify: x=1: √1 + 1 - 2 = 1 + 1 - 2 = 0 ✓
+  test('should filter extraneous root for sqrt(x) + x - 2 = 0', () => {
+    const e = expr('\\sqrt{x} + x - 2 = 0');
+    const result = e.solve('x')?.map((x) => x.json);
+    expect(result).toEqual([1]);
+  });
+
+  // √x - x + 2 = 0 has u = √x → u - u² + 2 = 0 → u² - u - 2 = 0
+  // → (u-2)(u+1) = 0 → u = 2 or u = -1
+  // x = u² → x = 4 or x = 1
+  // Verify: x=4: √4 - 4 + 2 = 2 - 4 + 2 = 0 ✓
+  // Verify: x=1: √1 - 1 + 2 = 1 - 1 + 2 = 2 ≠ 0 ❌ (extraneous from u=-1)
+  test('should filter extraneous root for sqrt(x) - x + 2 = 0', () => {
+    const e = expr('\\sqrt{x} - x + 2 = 0');
+    const result = e.solve('x')?.map((x) => x.json);
+    expect(result).toEqual([4]);
+  });
+
+  // x - 4√x + 3 = 0: u = √x → u² - 4u + 3 = 0 → (u-1)(u-3) = 0 → u = 1, 3
+  // x = u² → x = 1, 9
+  // Verify: x=1: 1 - 4(1) + 3 = 1 - 4 + 3 = 0 ✓
+  // Verify: x=9: 9 - 4(3) + 3 = 9 - 12 + 3 = 0 ✓
+  // Both solutions are valid in this case (no extraneous roots)
+  test('should keep both valid roots for x - 4sqrt(x) + 3 = 0', () => {
+    const e = expr('x - 4\\sqrt{x} + 3 = 0');
+    const result = e.solve('x')?.map((x) => x.json);
+    expect(result?.sort()).toEqual([1, 9].sort());
+  });
+
+  // x - 2√x - 3 = 0: u² - 2u - 3 = 0 → (u-3)(u+1) = 0 → u = 3 or u = -1
+  // x = u² → x = 9 or x = 1
+  // Verify: x=9: 9 - 2(3) - 3 = 9 - 6 - 3 = 0 ✓
+  // Verify: x=1: 1 - 2(1) - 3 = 1 - 2 - 3 = -4 ≠ 0 ❌ (extraneous from u=-1)
+  test('should filter extraneous root for x - 2sqrt(x) - 3 = 0', () => {
+    const e = expr('x - 2\\sqrt{x} - 3 = 0');
+    const result = e.solve('x')?.map((x) => x.json);
+    expect(result).toEqual([9]);
+  });
+
+  // 2x + 3√x - 2 = 0: 2u² + 3u - 2 = 0 → (2u-1)(u+2) = 0 → u = 1/2 or u = -2
+  // x = u² → x = 1/4 or x = 4
+  // Verify: x=1/4: 2(1/4) + 3(1/2) - 2 = 0.5 + 1.5 - 2 = 0 ✓
+  // Verify: x=4: 2(4) + 3(2) - 2 = 8 + 6 - 2 = 12 ≠ 0 ❌ (extraneous from u=-2)
+  test('should filter extraneous root for 2x + 3sqrt(x) - 2 = 0', () => {
+    const e = expr('2x + 3\\sqrt{x} - 2 = 0');
+    const result = e.solve('x')?.map((x) => x.json);
+    expect(result).toMatchInlineSnapshot(`
+      [
+        [
+          Rational,
+          1,
+          4,
+        ],
+      ]
+    `);
+  });
+});
+
 // Tests for trigonometric equations
 describe('SOLVING TRIGONOMETRIC EQUATIONS', () => {
   test('should solve sin(x) = 0', () => {


### PR DESCRIPTION
When solving square root equations using quadratic substitution
(u = √x → au² + bu + c = 0 → x = u²), extraneous roots could be
returned that satisfy the transformed equation but not the original.

The fix saves the original expression before algebraic transformations
(clearing denominators, harmonization) and uses it for validating
candidate solutions in validateRoots().

Examples that now correctly filter extraneous roots:
- √x = x - 2 → returns [4] (filters out x=1)
- √x + x - 2 = 0 → returns [1] (filters out x=4)
- √x - x + 2 = 0 → returns [4] (filters out x=1)
- x - 2√x - 3 = 0 → returns [9] (filters out x=1)
- 2x + 3√x - 2 = 0 → returns [1/4] (filters out x=4)

Added 6 new test cases for extraneous root filtering.

https://claude.ai/code/session_01KfmJZh5GN9ubmrEEN2dUp9