### PR TITLE
feat: add factorial and binomial simplification rules

### DIFF
--- a/src/compute-engine/boxed-expression/simplify.ts
+++ b/src/compute-engine/boxed-expression/simplify.ts
@@ -433,6 +433,8 @@ function simplifyNonCommutativeFunction(
   const isAbsRule = because?.startsWith('|');
   // Quotient-power distribution: a/(b/c)^d -> a*(c/b)^d eliminates nested fractions
   const isQuotientPowerRule = because === 'a / (b/c)^d -> a * (c/b)^d';
+  // Factorial factoring: n! - (n-1)! -> (n-1)! * (n-1) is structurally preferred
+  const isFactorialFactoring = because === 'factor common factorial';
   // Expand may produce more nodes but enables term cancellation
   // Accept when expansion reduces terms or eliminates Power-of-Add patterns
   const isExpandWithSimplification =
@@ -474,6 +476,7 @@ function simplifyNonCommutativeFunction(
     !isRootSignRule &&
     !isAbsRule &&
     !isQuotientPowerRule &&
+    !isFactorialFactoring &&
     !isExpandWithSimplification
   )
     return steps;

--- a/src/compute-engine/symbolic/simplify-factorial.ts
+++ b/src/compute-engine/symbolic/simplify-factorial.ts
@@ -1,0 +1,221 @@
+import type { Expression, RuleStep } from '../global-types';
+import { isFunction, isNumber } from '../boxed-expression/type-guards';
+
+/**
+ * Extracts base + integer offset from an expression.
+ * - Symbol `n` → { base: n, offset: 0 }
+ * - Add(n, 3) → { base: n, offset: 3 }
+ * - Add(n, -2) → { base: n, offset: -2 }
+ * - Multiply(2, x) → { base: Multiply(2, x), offset: 0 }
+ * - Number → null (pure numeric, no symbolic base)
+ */
+export function baseOffset(
+  expr: Expression
+): { base: Expression; offset: number } | null {
+  if (isNumber(expr)) return null;
+
+  if (expr.operator === 'Add' && isFunction(expr) && expr.nops === 2) {
+    const [op1, op2] = [expr.op1, expr.op2];
+    if (isNumber(op2) && Number.isInteger(op2.re) && !isNumber(op1))
+      return { base: op1, offset: op2.re };
+    if (isNumber(op1) && Number.isInteger(op1.re) && !isNumber(op2))
+      return { base: op2, offset: op1.re };
+  }
+
+  return { base: expr, offset: 0 };
+}
+
+/**
+ * Simplification rules for Binomial and Choose expressions.
+ *
+ * Patterns:
+ * - C(n, 0) → 1
+ * - C(n, 1) → n
+ * - C(n, n) → 1
+ * - C(n, n-1) → n
+ */
+export function simplifyBinomial(x: Expression): RuleStep | undefined {
+  if (x.operator !== 'Binomial' && x.operator !== 'Choose') return undefined;
+  if (!isFunction(x)) return undefined;
+
+  const n = x.op1;
+  const k = x.op2;
+  if (!n || !k) return undefined;
+
+  const ce = x.engine;
+
+  // C(n, 0) → 1
+  if (k.is(0)) return { value: ce.One, because: 'C(n,0) -> 1' };
+
+  // C(n, 1) → n
+  if (k.is(1)) return { value: n, because: 'C(n,1) -> n' };
+
+  // C(n, n) → 1
+  if (k.isSame(n)) return { value: ce.One, because: 'C(n,n) -> 1' };
+
+  // C(n, n-1) → n (structural check via baseOffset)
+  const nBO = baseOffset(n);
+  const kBO = baseOffset(k);
+  if (
+    nBO &&
+    kBO &&
+    nBO.base.isSame(kBO.base) &&
+    nBO.offset - kBO.offset === 1
+  )
+    return { value: n, because: 'C(n,n-1) -> n' };
+
+  return undefined;
+}
+
+/**
+ * Extracts factorial information from a term in an Add expression.
+ * Handles: Factorial(n), Negate(Factorial(n)), Multiply(c, Factorial(n))
+ */
+function extractFactorialTerm(
+  term: Expression
+): { coeff: number; factArg: Expression } | null {
+  // Direct: Factorial(n)
+  if (term.operator === 'Factorial' && isFunction(term))
+    return { coeff: 1, factArg: term.op1 };
+
+  // Negate(Factorial(n))
+  if (
+    term.operator === 'Negate' &&
+    isFunction(term) &&
+    term.op1.operator === 'Factorial' &&
+    isFunction(term.op1)
+  )
+    return { coeff: -1, factArg: term.op1.op1 };
+
+  // Multiply with integer coefficient and Factorial
+  if (term.operator === 'Multiply' && isFunction(term)) {
+    const ops = term.ops;
+    let factIdx = -1;
+    for (let i = 0; i < ops.length; i++) {
+      if (ops[i].operator === 'Factorial' && isFunction(ops[i])) {
+        if (factIdx >= 0) return null; // Multiple factorials
+        factIdx = i;
+      }
+    }
+    if (factIdx < 0) return null;
+
+    const factOp = ops[factIdx];
+    if (!isFunction(factOp)) return null;
+    const factArg = factOp.op1;
+    const others = ops.filter((_, i) => i !== factIdx);
+
+    if (
+      others.length === 1 &&
+      isNumber(others[0]) &&
+      Number.isInteger(others[0].re)
+    )
+      return { coeff: others[0].re, factArg };
+
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Simplification for Add expressions containing factorial terms.
+ * Factors out the common (smallest) factorial for symbolic expressions.
+ *
+ * Examples:
+ * - n! - (n-1)! → (n-1)! * (n - 1)
+ * - (n+1)! - n! → n! * n
+ * - (n+1)! + n! → n! * (n + 2)
+ */
+export function simplifyFactorialAdd(x: Expression): RuleStep | undefined {
+  if (x.operator !== 'Add' || !isFunction(x)) return undefined;
+
+  const ops = x.ops;
+  if (ops.length < 2) return undefined;
+
+  // Extract factorial info from each operand
+  const factTerms: Array<{
+    coeff: number;
+    factArg: Expression;
+    index: number;
+  }> = [];
+
+  for (let i = 0; i < ops.length; i++) {
+    const info = extractFactorialTerm(ops[i]);
+    if (info) factTerms.push({ ...info, index: i });
+  }
+
+  // Need at least 2 factorial terms
+  if (factTerms.length < 2) return undefined;
+
+  const ce = x.engine;
+
+  // Get base+offset for each factorial argument
+  const bos = factTerms.map((f) => ({ ...f, bo: baseOffset(f.factArg) }));
+  const validBOs = bos.filter((b) => b.bo !== null);
+
+  if (validBOs.length < 2) return undefined;
+
+  // Check if all share the same symbolic base
+  const refBase = validBOs[0].bo!.base;
+  if (!validBOs.every((b) => b.bo!.base.isSame(refBase))) return undefined;
+
+  // Find the minimum offset (smallest factorial)
+  let minOffset = Infinity;
+  for (const b of validBOs) {
+    if (b.bo!.offset < minOffset) minOffset = b.bo!.offset;
+  }
+
+  // Find the argument expression for the minimum factorial
+  const minFactArg = validBOs.find((v) => v.bo!.offset === minOffset)!.factArg;
+
+  // Build the inner terms: for each factorial, compute the partial product
+  const innerTerms: Expression[] = [];
+
+  for (const b of validBOs) {
+    const d = b.bo!.offset - minOffset;
+
+    if (d === 0) {
+      // This term IS the minimum factorial
+      innerTerms.push(ce.number(b.coeff));
+    } else if (d > 0 && d <= 8) {
+      // Build product (minArg+1)(minArg+2)...(minArg+d)
+      let product: Expression = minFactArg.add(ce.One);
+      for (let i = 2; i <= d; i++) {
+        product = product.mul(minFactArg.add(ce.number(i)));
+      }
+      if (b.coeff === 1) {
+        innerTerms.push(product);
+      } else if (b.coeff === -1) {
+        innerTerms.push(product.neg());
+      } else {
+        innerTerms.push(ce.number(b.coeff).mul(product));
+      }
+    } else {
+      // Difference too large or negative (shouldn't happen since we found min)
+      return undefined;
+    }
+  }
+
+  // Sum the inner terms
+  const innerSum =
+    innerTerms.length === 1
+      ? innerTerms[0]
+      : ce.function('Add', innerTerms);
+
+  // Result: Factorial(minFactArg) * innerSum
+  // Use _fn to avoid canonicalization that might re-distribute the product
+  const factorialExpr = ce._fn('Factorial', [minFactArg]);
+  const factored = ce._fn('Multiply', [factorialExpr, innerSum]);
+
+  // Include any non-factorial terms from the original Add
+  const factIndices = new Set(factTerms.map((f) => f.index));
+  const nonFactTerms = ops.filter((_, i) => !factIndices.has(i));
+
+  if (nonFactTerms.length > 0)
+    return {
+      value: ce._fn('Add', [factored, ...nonFactTerms]),
+      because: 'factor common factorial',
+    };
+
+  return { value: factored, because: 'factor common factorial' };
+}

--- a/test/compute-engine/arithmetic.test.ts
+++ b/test/compute-engine/arithmetic.test.ts
@@ -1611,3 +1611,145 @@ describe('SPECIAL FUNCTIONS TYPE SIGNATURES', () => {
     expect(expr.toString()).toMatchInlineSnapshot(`PolyGamma(2, x) + 1`);
   });
 });
+
+describe('Factorial simplification', () => {
+  // Factorial division: concrete integers
+  it('10!/7! should simplify to 720', () => {
+    expect(
+      ce
+        .box(['Divide', ['Factorial', 10], ['Factorial', 7]])
+        .simplify()
+        .toString()
+    ).toMatchInlineSnapshot(`720`);
+  });
+
+  it('5!/10! should simplify to 1/30240', () => {
+    expect(
+      ce
+        .box(['Divide', ['Factorial', 5], ['Factorial', 10]])
+        .simplify()
+        .toString()
+    ).toMatchInlineSnapshot(`1/30240`);
+  });
+
+  it('7!/7! should simplify to 1', () => {
+    expect(
+      ce
+        .box(['Divide', ['Factorial', 7], ['Factorial', 7]])
+        .simplify()
+        .toString()
+    ).toMatchInlineSnapshot(`1`);
+  });
+
+  // Factorial division: symbolic
+  it('(b+1)!/b! should simplify to b + 1', () => {
+    expect(
+      ce
+        .box(['Divide', ['Factorial', ['Add', 'b', 1]], ['Factorial', 'b']])
+        .simplify()
+        .toString()
+    ).toMatchInlineSnapshot(`b + 1`);
+  });
+
+  it('b!/(b-1)! should simplify to b', () => {
+    expect(
+      ce
+        .box([
+          'Divide',
+          ['Factorial', 'b'],
+          ['Factorial', ['Add', 'b', -1]],
+        ])
+        .simplify()
+        .toString()
+    ).toMatchInlineSnapshot(`b`);
+  });
+
+  // Binomial detection from factorial division
+  it('10!/(3!*7!) should simplify to 120', () => {
+    expect(
+      ce
+        .box([
+          'Divide',
+          ['Factorial', 10],
+          ['Multiply', ['Factorial', 3], ['Factorial', 7]],
+        ])
+        .simplify()
+        .toString()
+    ).toMatchInlineSnapshot(`120`);
+  });
+
+  // Factorial sums/differences: symbolic factoring
+  it('(b+1)! - b! should simplify to b * b!', () => {
+    expect(
+      ce
+        .box([
+          'Subtract',
+          ['Factorial', ['Add', 'b', 1]],
+          ['Factorial', 'b'],
+        ])
+        .simplify()
+        .toString()
+    ).toMatchInlineSnapshot(`b * b!`);
+  });
+
+  it('(b+1)! + b! should simplify to (b + 2) * b!', () => {
+    expect(
+      ce
+        .box(['Add', ['Factorial', ['Add', 'b', 1]], ['Factorial', 'b']])
+        .simplify()
+        .toString()
+    ).toMatchInlineSnapshot(`(b + 2) * b!`);
+  });
+
+  it('b! - (b-1)! should simplify to (b - 1) * (b - 1)!', () => {
+    expect(
+      ce
+        .box([
+          'Subtract',
+          ['Factorial', 'b'],
+          ['Factorial', ['Add', 'b', -1]],
+        ])
+        .simplify()
+        .toString()
+    ).toMatchInlineSnapshot(`(b - 1) * (b - 1)!`);
+  });
+
+  it('2*b! + (b+1)! should simplify to (b + 3) * b!', () => {
+    expect(
+      ce
+        .box([
+          'Add',
+          ['Multiply', 2, ['Factorial', 'b']],
+          ['Factorial', ['Add', 'b', 1]],
+        ])
+        .simplify()
+        .toString()
+    ).toMatchInlineSnapshot(`(b + 3) * b!`);
+  });
+});
+
+describe('Binomial/Choose simplification', () => {
+  it('Binomial(b, 0) should simplify to 1', () => {
+    expect(
+      ce.box(['Binomial', 'b', 0]).simplify().toString()
+    ).toMatchInlineSnapshot(`1`);
+  });
+
+  it('Binomial(b, 1) should simplify to b', () => {
+    expect(
+      ce.box(['Binomial', 'b', 1]).simplify().toString()
+    ).toMatchInlineSnapshot(`b`);
+  });
+
+  it('Binomial(b, b) should simplify to 1', () => {
+    expect(
+      ce.box(['Binomial', 'b', 'b']).simplify().toString()
+    ).toMatchInlineSnapshot(`1`);
+  });
+
+  it('Binomial(5, 2) should evaluate to 10', () => {
+    expect(
+      ce.box(['Binomial', 5, 2]).evaluate().toString()
+    ).toMatchInlineSnapshot(`10`);
+  });
+});


### PR DESCRIPTION
Add simplification rules for factorial quotients (n!/k! via partial products),
binomial detection (n!/(k!(n-k)!) → Binomial(n,k)), binomial identities
(C(n,0)→1, C(n,1)→n, C(n,n)→1), and factorial sum factoring
(n!-(n-1)! → (n-1)!*(n-1)). Works for both concrete integers and symbolic
expressions.

https://claude.ai/code/session_0114soGikCy942KAFJU8xn79