### PR TITLE
`simplify()` fixes from PR/301

### DIFF
--- a/src/compute-engine/boxed-expression/simplify.ts
+++ b/src/compute-engine/boxed-expression/simplify.ts
@@ -407,7 +407,7 @@ function simplifyNonCommutativeFunction(
   let last = result.at(-1)!.value;
   if (last.isSame(expr)) return steps;
 
-  last = simplifyOperands(last);
+  last = simplifyOperands(last, options);
 
   // If the simplified expression is not cheaper, we're done.
   // Exception: power combination results (e.g., -4·2^x → -2^(x+2)) may be


### PR DESCRIPTION
## Description

Is constituted by the fixes in the domain of simplification, as [requested](https://github.com/cortex-js/compute-engine/pull/301#issuecomment-4414127974) in #301. Constituted by sole commit

- [fix: dispatch options (including rules) to simplifyOperands in simplifyNonCommutativeFunction](https://github.com/cortex-js/compute-engine/commit/ddcc797387d68d3072a829ae48b3d37752369690)

Forgoes inclusion of '[Refactor (workaround): during simplification, do not simplify *all* numeric operands of 'lazy' operator definitions](https://github.com/cortex-js/compute-engine/pull/301/changes/5d974d261988513ee9da5602af3cfeea74ced0d7)' (from PR/301); in favour of this being raised as an issue in #306.

