### PR TITLE
feat(latex): add sourceOffsets to parser-generated Error nodes

### DIFF
--- a/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
+++ b/src/compute-engine/boxed-expression/abstract-boxed-expression.ts
@@ -132,10 +132,13 @@ export abstract class _BoxedExpression implements Expression {
    *  not generated synthetically
    */
   readonly verbatimLatex?: string;
+  readonly sourceOffsets?: [start: number, end: number];
 
   constructor(ce: ComputeEngine, metadata?: Metadata) {
     this.engine = ce;
     if (metadata?.latex !== undefined) this.verbatimLatex = metadata.latex;
+    if (metadata?.sourceOffsets !== undefined)
+      this.sourceOffsets = metadata.sourceOffsets;
   }
 
   /**
@@ -336,7 +339,7 @@ export abstract class _BoxedExpression implements Expression {
         (typeof options.metadata === 'string' && options.metadata === 'all') ||
         options.metadata?.includes('all')
       ) {
-        defaultOptions.metadata = ['latex', 'wikidata'];
+        defaultOptions.metadata = ['latex', 'wikidata', 'sourceOffsets'];
       } else if (Array.isArray(options.metadata)) {
         defaultOptions.metadata = options.metadata;
       }

--- a/src/compute-engine/boxed-expression/box.ts
+++ b/src/compute-engine/boxed-expression/box.ts
@@ -478,6 +478,11 @@ export function box(
       ? {
           latex: (expr as ExpressionObject & { latex?: string }).latex,
           wikidata: (expr as ExpressionObject & { wikidata?: string }).wikidata,
+          sourceOffsets: (
+            expr as ExpressionObject & {
+              sourceOffsets?: [start: number, end: number];
+            }
+          ).sourceOffsets,
         }
       : undefined;
 

--- a/src/compute-engine/boxed-expression/boxed-function.ts
+++ b/src/compute-engine/boxed-expression/boxed-function.ts
@@ -319,13 +319,23 @@ export class BoxedFunction
         this.isValid ? sortOperands(this._operator, ys) : ys,
         {
           form: 'structural',
+          metadata: {
+            latex: this.verbatimLatex,
+            sourceOffsets: this.sourceOffsets,
+          },
         }
       );
     }
     return this.engine.function(
       this._operator,
       this.ops.map((x) => x.structural),
-      { form: 'structural' }
+      {
+        form: 'structural',
+        metadata: {
+          latex: this.verbatimLatex,
+          sourceOffsets: this.sourceOffsets,
+        },
+      }
     );
   }
 

--- a/src/compute-engine/boxed-expression/serialize.ts
+++ b/src/compute-engine/boxed-expression/serialize.ts
@@ -470,16 +470,28 @@ function serializeJsonFunction(
   // Determine if we have some wikidata metadata
   if (!options.metadata.includes('wikidata')) md.wikidata = '';
 
+  const sourceOffsets = md.sourceOffsets;
+
   //  Is shorthand allowed, and no metadata to include
-  if (!md.latex && !md.wikidata && options.shorthands.includes('function'))
+  if (
+    !md.latex &&
+    !md.wikidata &&
+    !sourceOffsets &&
+    options.shorthands.includes('function')
+  )
     return fn;
 
   // No shorthand allowed, or some metadata to include
-  if (md.latex && md.wikidata)
-    return { fn, latex: md.latex, wikidata: md.wikidata } as MathJsonExpression;
-  if (md.latex) return { fn, latex: md.latex } as MathJsonExpression;
-  if (md.wikidata) return { fn, wikidata: md.wikidata } as MathJsonExpression;
-  return { fn } as MathJsonExpression;
+  const result = { fn } as {
+    fn: MathJsonExpression;
+    latex?: string;
+    wikidata?: string;
+    sourceOffsets?: [start: number, end: number];
+  };
+  if (md.latex) result.latex = md.latex;
+  if (md.wikidata) result.wikidata = md.wikidata;
+  if (sourceOffsets) result.sourceOffsets = sourceOffsets;
+  return result as MathJsonExpression;
 }
 
 function serializeJsonString(
@@ -923,11 +935,13 @@ export function serializeJson(
         {
           latex: expr.verbatimLatex,
           wikidata,
+          sourceOffsets: expr.sourceOffsets,
         }
       );
     return serializeJsonFunction(ce, expr.operator, structuralOps, options, {
       latex: expr.verbatimLatex,
       wikidata,
+      sourceOffsets: expr.sourceOffsets,
     });
   }
 

--- a/src/compute-engine/latex-syntax/dictionary/definitions-arithmetic.ts
+++ b/src/compute-engine/latex-syntax/dictionary/definitions-arithmetic.ts
@@ -81,8 +81,9 @@ function parseRoot(parser: Parser): MathJsonExpression | null {
   const degree = parser.parseOptionalGroup();
   const base = parser.parseGroup() ?? parser.parseToken();
   if (isEmptySequence(base)) {
-    if (degree !== null) return ['Root', MISSING, missingIfEmpty(degree)];
-    return ['Sqrt', MISSING];
+    const missing = parser.error('missing', parser.index);
+    if (degree !== null) return ['Root', missing, missingIfEmpty(degree)];
+    return ['Sqrt', missing];
   }
   if (degree !== null) return ['Root', base, degree];
   return ['Sqrt', base];
@@ -422,11 +423,21 @@ function parseFraction(parser: Parser): MathJsonExpression | null {
   if (numer === null) {
     numer = parser.parseToken();
     denom = parser.parseToken();
+    numer = missingIfEmpty(numer);
+    denom = missingIfEmpty(denom);
   } else {
+    // Report an empty numerator/denominator (e.g. `\frac{}{}`) as a
+    // missing-operand error positioned at the empty group, so the editor can
+    // flag it. `error('missing', …)` is emitted right after each group is
+    // consumed, while the parser is positioned at that group.
+    numer = isEmptySequence(numer)
+      ? parser.error('missing', parser.index)
+      : numer;
     denom = parser.parseGroup();
+    denom = isEmptySequence(denom)
+      ? parser.error('missing', parser.index)
+      : denom;
   }
-  numer = missingIfEmpty(numer);
-  denom = missingIfEmpty(denom);
   if (
     operator(numer) === 'PartialDerivative' &&
     (operator(denom) === 'PartialDerivative' ||

--- a/src/compute-engine/latex-syntax/parse.ts
+++ b/src/compute-engine/latex-syntax/parse.ts
@@ -609,6 +609,20 @@ export class _Parser implements Parser {
     return tokensToString(this._tokens.slice(start, end));
   }
 
+  sourceOffsets(
+    startToken: number,
+    endToken: number = this.index
+  ): [start: number, end: number] {
+    // Map token indices to character offsets in the serialized LaTeX by
+    // measuring the length of the token prefix. For input that round-trips
+    // through `tokensToString` unchanged (e.g. editor-generated LaTeX, which
+    // has no comments or Unicode normalization), these offsets match the
+    // original input string.
+    const start = this.latex(0, startToken).length;
+    const end = this.latex(0, endToken).length;
+    return start <= end ? [start, end] : [end, start];
+  }
+
   // latexBefore(): string {
   //   return this.latex(0, this.index);
   // }
@@ -2678,9 +2692,14 @@ export class _Parser implements Parser {
     }
 
     const latex = this.latex(fromToken, this.index);
-    return latex
+    const fn: [MathJsonSymbol, ...MathJsonExpression[]] = latex
       ? ['Error', msg, ['LatexString', { str: latex }]]
       : ['Error', msg];
+    const isMissing = typeof code === 'string' && code === 'missing';
+    const sourceOffsets = isMissing
+      ? this.sourceOffsets(this.index, this.index)
+      : this.sourceOffsets(fromToken, this.index);
+    return { fn, sourceOffsets };
   }
 
   private isFunctionOperator(id: MathJsonSymbol | null): boolean {

--- a/src/compute-engine/latex-syntax/types.ts
+++ b/src/compute-engine/latex-syntax/types.ts
@@ -904,11 +904,28 @@ export interface Parser {
    */
   latex(start: number, end?: number): string;
 
-  /** Return an error expression with the specified code and arguments */
+  /**
+   * Return an error expression with the specified code and arguments.
+   *
+   * The returned `Error` expression includes `sourceOffsets` metadata with
+   * zero-based, end-exclusive offsets into the serialized LaTeX. Missing-token
+   * errors use a collapsed range at the parser position.
+   */
   error(
     code: string | [string, ...MathJsonExpression[]],
     fromToken: number
   ): MathJsonExpression;
+
+  /**
+   * Return source offsets for a token range, as zero-based, end-exclusive
+   * character offsets into the serialized LaTeX (`tokensToString`). For input
+   * that round-trips unchanged (e.g. editor-generated LaTeX), these match the
+   * original input string.
+   */
+  sourceOffsets(
+    startToken: number,
+    endToken?: number
+  ): [start: number, end: number];
 
   /** If there are any space, advance the index until a non-space is encountered */
   skipSpace(): boolean;

--- a/src/compute-engine/types-expression.ts
+++ b/src/compute-engine/types-expression.ts
@@ -706,6 +706,9 @@ export interface Expression {
    */
   verbatimLatex?: string;
 
+  /** Source offsets in the original source string, when available. */
+  sourceOffsets?: [start: number, end: number];
+
   /** If `true`, this expression is in a canonical form. */
   get isCanonical(): boolean;
 

--- a/src/compute-engine/types-kernel-serialization.ts
+++ b/src/compute-engine/types-kernel-serialization.ts
@@ -38,7 +38,7 @@ export type JsonSerializationOptions = {
    * Metadata fields to include. When metadata is included, shorthand notation
    * is disabled for affected nodes.
    */
-  metadata: ('all' | 'wikidata' | 'latex')[];
+  metadata: ('all' | 'wikidata' | 'latex' | 'sourceOffsets')[];
 
   /**
    * If true, detect and serialize repeating decimals (for example `0.(3)`).
@@ -237,6 +237,8 @@ export type FormOption =
 export type Metadata = {
   latex?: string | undefined;
   wikidata?: string | undefined;
+  /** Zero-based, end-exclusive offsets into the original source string. */
+  sourceOffsets?: [start: number, end: number] | undefined;
 };
 
 /**

--- a/src/math-json/types.ts
+++ b/src/math-json/types.ts
@@ -64,7 +64,16 @@ export type MathJsonAttributes = {
 
   /**
    * A character offset in `sourceContent` or `sourceUrl` from which this
-   * expression was generated.
+   * expression was generated. Offsets are zero-based and the end offset is
+   * exclusive.
+   *
+   * When present on a parser-generated `Error` expression from LaTeX parsing,
+   * offsets refer to the serialized LaTeX of the parsed tokens. Missing-token
+   * diagnostics use a collapsed (zero-width) range at the parser position
+   * where the token was expected. For input that round-trips through the
+   * tokenizer unchanged (no comments, Unicode normalization, or macro
+   * expansion) — such as editor-generated LaTeX — these offsets match the
+   * original input string.
    */
   sourceOffsets?: [start: number, end: number];
 };

--- a/src/math-json/utils.ts
+++ b/src/math-json/utils.ts
@@ -77,7 +77,7 @@ export function isExpressionObject(
 
 /**
  * Returns true if `expr` has at least one recognized metadata property
- * (`latex` or `wikidata`) with a non-undefined value.
+ * with a non-undefined value.
  */
 export function hasMetaData(
   expr: MathJsonExpression | null
@@ -85,7 +85,8 @@ export function hasMetaData(
   return (
     isExpressionObject(expr) &&
     ((expr as MathJsonAttributes).latex !== undefined ||
-      (expr as MathJsonAttributes).wikidata !== undefined)
+      (expr as MathJsonAttributes).wikidata !== undefined ||
+      (expr as MathJsonAttributes).sourceOffsets !== undefined)
   );
 }
 

--- a/test/compute-engine/incomplete-expressions.test.ts
+++ b/test/compute-engine/incomplete-expressions.test.ts
@@ -12,29 +12,45 @@ describe('basic', () => {
     expect(parse('\\frac{')).toMatchInlineSnapshot(`
       [
         "Divide",
-        ["Error", "expected-closing-delimiter", ["LatexString", "{"]],
-        ["Error", "'missing'"]
+        {
+          fn: ["Error", "expected-closing-delimiter", ["LatexString", "{"]];
+            sourceOffsets: [5, 6]
+        },
+        {fn: ["Error", "'missing'"]; sourceOffsets: [6, 6]}
       ]
     `);
     expect(parse('\\frac{{')).toMatchInlineSnapshot(`
       [
         "Divide",
-        ["Error", "expected-closing-delimiter", ["LatexString", "{"]],
-        ["Error", "'missing'"]
+        {
+          fn: ["Error", "expected-closing-delimiter", ["LatexString", "{"]];
+            sourceOffsets: [6, 7]
+        },
+        {fn: ["Error", "'missing'"]; sourceOffsets: [7, 7]}
       ]
     `);
     expect(parse('\\frac{}}')).toMatchInlineSnapshot(`
       [
         "Tuple",
-        ["Divide", ["Error", "'missing'"], ["Error", "'missing'"]],
-        ["Error", "unexpected-closing-delimiter", ["LatexString", "}"]]
+        [
+          "Divide",
+          {fn: ["Error", "'missing'"]; sourceOffsets: [7, 7]},
+          {fn: ["Error", "'missing'"]; sourceOffsets: [7, 7]}
+        ],
+        {
+          fn: ["Error", "unexpected-closing-delimiter", ["LatexString", "}"]];
+            sourceOffsets: [7, 8]
+        }
       ]
     `);
     expect(parse('\\frac{1}}')).toMatchInlineSnapshot(`
       [
         "Tuple",
-        ["Divide", 1, ["Error", "'missing'"]],
-        ["Error", "unexpected-closing-delimiter", ["LatexString", "}"]]
+        ["Divide", 1, {fn: ["Error", "'missing'"]; sourceOffsets: [8, 8]}],
+        {
+          fn: ["Error", "unexpected-closing-delimiter", ["LatexString", "}"]];
+            sourceOffsets: [8, 9]
+        }
       ]
     `);
     expect(parse('\\frac{1}{2')).toMatchInlineSnapshot(`
@@ -44,54 +60,81 @@ describe('basic', () => {
         [
           "Tuple",
           2,
-          ["Error", "expected-closing-delimiter", ["LatexString", "{2"]]
+          {
+            fn: ["Error", "expected-closing-delimiter", ["LatexString", "{2"]];
+                sourceOffsets: [8, 10]
+          }
         ]
       ]
     `);
     expect(parse('\\sqrt{}')).toMatchInlineSnapshot(
-      `["Sqrt", ["Error", "'missing'"]]`
+      `["Sqrt", {fn: ["Error", "'missing'"]; sourceOffsets: [7, 7]}]`
     );
     expect(parse('\\sqrt{}{}')).toMatchInlineSnapshot(
-      `["Sqrt", ["Error", "'missing'"]]`
+      `["Sqrt", {fn: ["Error", "'missing'"]; sourceOffsets: [7, 7]}]`
     );
     expect(parse('\\sqrt')).toMatchInlineSnapshot(
-      `["Sqrt", ["Error", "'missing'"]]`
+      `["Sqrt", {fn: ["Error", "'missing'"]; sourceOffsets: [5, 5]}]`
     );
   });
 
   test('Semantic Errors', () => {
-    expect(parse('1+')).toMatchInlineSnapshot(
-      `["Sequence", 1, ["Error", "unexpected-operator", ["LatexString", "+"]]]`
-    );
+    expect(parse('1+')).toMatchInlineSnapshot(`
+      [
+        "Sequence",
+        1,
+        {
+          fn: ["Error", "unexpected-operator", ["LatexString", "+"]];
+            sourceOffsets: [1, 2]
+        }
+      ]
+    `);
     expect(parse('1\\times')).toMatchInlineSnapshot(
       `["Multiply", 1, ["Error", "'missing'"]]`
     );
-    expect(parse('\\times')).toMatchInlineSnapshot(
-      `["Error", "unexpected-command", ["LatexString", "\\times"]]`
-    );
+    expect(parse('\\times')).toMatchInlineSnapshot(`
+      {
+        fn: ["Error", "unexpected-command", ["LatexString", "\\times"]];
+        sourceOffsets: [0, 6]
+      }
+    `);
     expect(parse('\\times3')).toMatchInlineSnapshot(`
       [
         "Tuple",
-        ["Error", "unexpected-command", ["LatexString", "\\times"]],
+        {
+          fn: ["Error", "unexpected-command", ["LatexString", "\\times"]];
+            sourceOffsets: [0, 6]
+        },
         3
       ]
     `);
     expect(parse('2*')).toMatchInlineSnapshot(
       `["Multiply", 2, ["Error", "'missing'"]]`
     );
-    expect(parse('\\frac{}{}')).toMatchInlineSnapshot(
-      `["Divide", ["Error", "'missing'"], ["Error", "'missing'"]]`
-    );
+    expect(parse('\\frac{}{}')).toMatchInlineSnapshot(`
+      [
+        "Divide",
+        {fn: ["Error", "'missing'"]; sourceOffsets: [7, 7]},
+        {fn: ["Error", "'missing'"]; sourceOffsets: [9, 9]}
+      ]
+    `);
     expect(parse('\\frac{1}{}')).toMatchInlineSnapshot(
-      `["Divide", 1, ["Error", "'missing'"]]`
+      `["Divide", 1, {fn: ["Error", "'missing'"]; sourceOffsets: [10, 10]}]`
     );
     expect(parse('\\frac{}{2}')).toMatchInlineSnapshot(
-      `["Divide", ["Error", "'missing'"], 2]`
+      `["Divide", {fn: ["Error", "'missing'"]; sourceOffsets: [7, 7]}, 2]`
     );
 
-    expect(parse('=x')).toMatchInlineSnapshot(
-      `["Equal", ["Error", "'missing'", ["LatexString", "="]], "x"]`
-    );
+    expect(parse('=x')).toMatchInlineSnapshot(`
+      [
+        "Equal",
+        {
+          fn: ["Error", "'missing'", ["LatexString", "="]];
+            sourceOffsets: [1, 1]
+        },
+        "x"
+      ]
+    `);
   });
 
   test('Valid Incomplete', () => {

--- a/test/compute-engine/latex-syntax/errors.test.ts
+++ b/test/compute-engine/latex-syntax/errors.test.ts
@@ -1,4 +1,6 @@
 import { engine } from '../../utils';
+import { LatexSyntax } from '../../../src/latex-syntax';
+import type { MathJsonExpression } from '../../../src/math-json/types';
 
 engine.declare('g', 'function');
 
@@ -6,13 +8,105 @@ function check(s: string, f: jest.ProvidesCallback) {
   describe(s, () => test(s, f));
 }
 
+type ErrorExpressionObject = {
+  fn: ['Error', ...MathJsonExpression[]];
+  sourceOffsets?: [start: number, end: number];
+};
+
+function errorCode(expr: ErrorExpressionObject): string | undefined {
+  const code = expr.fn[1];
+  if (typeof code === 'string') return code.replace(/^'|'$/g, '');
+  if (code && typeof code === 'object' && !Array.isArray(code) && 'str' in code)
+    return code.str.replace(/^'|'$/g, '');
+  if (Array.isArray(code) && code[0] === 'ErrorCode') {
+    const head = code[1];
+    if (typeof head === 'string') return head.replace(/^'|'$/g, '');
+    if (head && typeof head === 'object' && 'str' in head)
+      return head.str.replace(/^'|'$/g, '');
+  }
+  return undefined;
+}
+
+function collectErrors(expr: MathJsonExpression): ErrorExpressionObject[] {
+  const result: ErrorExpressionObject[] = [];
+
+  function visit(x: MathJsonExpression): void {
+    if (Array.isArray(x)) {
+      if (x[0] === 'Error')
+        result.push({ fn: x as ErrorExpressionObject['fn'] });
+      for (const child of x.slice(1)) visit(child);
+      return;
+    }
+
+    if (x && typeof x === 'object' && 'fn' in x) {
+      if (x.fn[0] === 'Error') result.push(x as ErrorExpressionObject);
+      for (const child of x.fn.slice(1)) visit(child);
+    }
+  }
+
+  visit(expr);
+  return result;
+}
+
+function findError(
+  expr: MathJsonExpression,
+  code: string
+): ErrorExpressionObject {
+  const result = collectErrors(expr).find((error) => errorCode(error) === code);
+  expect(result).toBeDefined();
+  return result!;
+}
+
+describe('Parser Error source offsets', () => {
+  test('raw parser errors identify the original source range for unknown commands', () => {
+    const syntax = new LatexSyntax();
+    const expr = syntax.parse('\\foo')!;
+    const error = findError(expr, 'unexpected-command');
+
+    expect(error.fn[0]).toBe('Error');
+    expect(error.sourceOffsets).toEqual([0, 4]);
+  });
+
+  test('nested parser errors survive ComputeEngine.parse().toMathJson()', () => {
+    const expr = engine.parse('1+\\oops+2')!.toMathJson();
+    const error = findError(expr, 'unexpected-command');
+
+    expect(error.fn[0]).toBe('Error');
+    expect(error.sourceOffsets).toEqual([2, 7]);
+  });
+
+  test('unexpected delimiters identify the delimiter source range', () => {
+    const expr = engine.parse(')+1')!.toMathJson();
+    const error = findError(expr, 'unexpected-delimiter');
+
+    expect(error.sourceOffsets).toEqual([0, 1]);
+  });
+
+  test('missing parser operands use a zero-width source range at the parser position', () => {
+    const expr = engine.parse('1+\\sqrt')!.toMathJson();
+    const error = findError(expr, 'missing');
+
+    expect(error.sourceOffsets).toEqual([7, 7]);
+  });
+
+  test('missing closing delimiters identify the unterminated group range', () => {
+    const expr = engine.parse('x_{a')!.toMathJson();
+    const error = findError(expr, 'expected-closing-delimiter');
+
+    expect(error.sourceOffsets).toEqual([2, 4]);
+  });
+});
+
 check('Syntax error inside group with invisible operator', () =>
   expect(engine.parse('{2\\pi)}')).toMatchInlineSnapshot(`
     [
       "Tuple",
       2,
       "Pi",
-      ["Error", "expected-closing-delimiter", ["LatexString", "{2\\pi)}"]]
+      {
+        fn: ["Error", "expected-closing-delimiter", ["LatexString", "{2\\pi)}"]];
+          sourceOffsets: [0, 7]
+      }
     ]
   `)
 );
@@ -22,15 +116,21 @@ check('Valid empty group', () =>
 );
 
 check('Invalid open delimiter', () =>
-  expect(engine.parse(')+1')).toMatchInlineSnapshot(
-    `["Error", "unexpected-delimiter", ["LatexString", ")"]]`
-  )
+  expect(engine.parse(')+1')).toMatchInlineSnapshot(`
+    {
+      fn: ["Error", "unexpected-delimiter", ["LatexString", ")"]];
+      sourceOffsets: [0, 1]
+    }
+  `)
 );
 
 check('Unknown symbol', () =>
-  expect(engine.parse('\\oops')).toMatchInlineSnapshot(
-    `["Error", "unexpected-command", ["LatexString", "\\oops"]]`
-  )
+  expect(engine.parse('\\oops')).toMatchInlineSnapshot(`
+    {
+      fn: ["Error", "unexpected-command", ["LatexString", "\\oops"]];
+      sourceOffsets: [0, 5]
+    }
+  `)
 );
 
 check('Unknown symbol in argument list', () =>
@@ -38,7 +138,10 @@ check('Unknown symbol in argument list', () =>
     [
       "Add",
       1,
-      ["Error", "unexpected-command", ["LatexString", "\\oops"]],
+      {
+        fn: ["Error", "unexpected-command", ["LatexString", "\\oops"]];
+          sourceOffsets: [2, 7]
+      },
       2
     ]
   `)
@@ -51,7 +154,10 @@ check('Unknown command with arguments', () =>
       1,
       [
         "Tuple",
-        ["Error", "unexpected-command", ["LatexString", "\\oops"]],
+        {
+          fn: ["Error", "unexpected-command", ["LatexString", "\\oops"]];
+              sourceOffsets: [2, 7]
+        },
         "b",
         "a",
         "r"
@@ -66,11 +172,14 @@ check('Unknown environment', () =>
     [
       "Add",
       1,
-      [
-        "Error",
-        ["ErrorCode", "unknown-environment", "'oops'"],
-        ["LatexString", "\\begin{oops}\\end{oops}"]
-      ],
+      {
+        fn: [
+          "Error",
+          ["ErrorCode", "unknown-environment", "'oops'"],
+          ["LatexString", "\\begin{oops}\\end{oops}"]
+        ];
+          sourceOffsets: [2, 24]
+      },
       2
     ]
   `)
@@ -81,7 +190,14 @@ check('Unbalanced environment by name', () =>
     [
       "Add",
       1,
-      ["Error", "unbalanced-environment", ["LatexString", "\\end{oops}+2"]]
+      {
+        fn: [
+          "Error",
+          "unbalanced-environment",
+          ["LatexString", "\\end{oops}+2"]
+        ];
+          sourceOffsets: [15, 27]
+      }
     ]
   `)
 );
@@ -93,7 +209,10 @@ check('Unbalanced environment, \\end without \\begin', () =>
       1,
       [
         "Tuple",
-        ["Error", "unexpected-command", ["LatexString", "\\end"]],
+        {
+          fn: ["Error", "unexpected-command", ["LatexString", "\\end"]];
+              sourceOffsets: [2, 6]
+        },
         "c",
         "a",
         "s",
@@ -106,9 +225,12 @@ check('Unbalanced environment, \\end without \\begin', () =>
 );
 
 check('Unbalanced environment, \\begin without \\end', () =>
-  expect(engine.parse('\\begin{cases}1+2')).toMatchInlineSnapshot(
-    `["Error", "unbalanced-environment", ["LatexString", "1+2"]]`
-  )
+  expect(engine.parse('\\begin{cases}1+2')).toMatchInlineSnapshot(`
+    {
+      fn: ["Error", "unbalanced-environment", ["LatexString", "1+2"]];
+      sourceOffsets: [13, 16]
+    }
+  `)
 );
 
 // REVIEW.md C3: an unbalanced brace in an environment name at end of input
@@ -124,28 +246,43 @@ check('Environment without name', () =>
     [
       "Add",
       1,
-      ["Error", "expected-environment-name", ["LatexString", "\\begin"]],
+      {
+        fn: ["Error", "expected-environment-name", ["LatexString", "\\begin"]];
+          sourceOffsets: [4, 10]
+      },
       2
     ]
   `)
 );
 
 check('Missing argument with \\sqrt custom parser', () =>
-  expect(engine.parse('1+\\sqrt')).toMatchInlineSnapshot(
-    `["Add", 1, ["Sqrt", ["Error", "'missing'"]]]`
-  )
+  expect(engine.parse('1+\\sqrt')).toMatchInlineSnapshot(`
+    [
+      "Add",
+      1,
+      ["Sqrt", {fn: ["Error", "'missing'"]; sourceOffsets: [7, 7]}]
+    ]
+  `)
 );
 
 check('Paren instead of braces with \\sqrt', () =>
-  expect(engine.parse('\\sqrt[x](y)')).toMatchInlineSnapshot(
-    `["Tuple", ["Root", ["Error", "'missing'"], "x"], "y"]`
-  )
+  expect(engine.parse('\\sqrt[x](y)')).toMatchInlineSnapshot(`
+    [
+      "Tuple",
+      ["Root", {fn: ["Error", "'missing'"]; sourceOffsets: [8, 8]}, "x"],
+      "y"
+    ]
+  `)
 );
 
 check('Missing 1 argument with \\frac custom parser', () =>
-  expect(engine.parse('1+\\frac{2}')).toMatchInlineSnapshot(
-    `["Add", 1, ["Divide", 2, ["Error", "'missing'"]]]`
-  )
+  expect(engine.parse('1+\\frac{2}')).toMatchInlineSnapshot(`
+    [
+      "Add",
+      1,
+      ["Divide", 2, {fn: ["Error", "'missing'"]; sourceOffsets: [10, 10]}]
+    ]
+  `)
 );
 
 check('Missing all arguments with \\frac custom parser', () =>
@@ -159,7 +296,10 @@ check('Missing argument with \\placeholder parser', () =>
     [
       "Sequence",
       1,
-      ["Error", "unexpected-operator", ["LatexString", "+\\placeholder"]]
+      {
+        fn: ["Error", "unexpected-operator", ["LatexString", "+\\placeholder"]];
+          sourceOffsets: [1, 14]
+      }
     ]
   `)
 );
@@ -200,7 +340,10 @@ check('Invalid infix operator', () =>
   expect(engine.parse('\\times 3')).toMatchInlineSnapshot(`
     [
       "Tuple",
-      ["Error", "unexpected-command", ["LatexString", "\\times"]],
+      {
+        fn: ["Error", "unexpected-command", ["LatexString", "\\times"]];
+          sourceOffsets: [0, 6]
+      },
       3
     ]
   `)
@@ -213,9 +356,15 @@ check('Invalid prefix operator', () =>
 );
 
 check('Invalid postfix operator', () =>
-  expect(engine.parse('! 3')).toMatchInlineSnapshot(
-    `["Factorial", ["Error", "'missing'", ["LatexString", "!"]]]`
-  )
+  expect(engine.parse('! 3')).toMatchInlineSnapshot(`
+    [
+      "Factorial",
+      {
+        fn: ["Error", "'missing'", ["LatexString", "!"]];
+          sourceOffsets: [1, 1]
+      }
+    ]
+  `)
 );
 
 check('Supsub syntax error', () =>
@@ -242,7 +391,10 @@ check('Supsub syntax error', () =>
       [
         "InvisibleOperator",
         "a",
-        ["Error", "expected-closing-delimiter", ["LatexString", "{a"]]
+        {
+          fn: ["Error", "expected-closing-delimiter", ["LatexString", "{a"]];
+              sourceOffsets: [2, 4]
+        }
       ]
     ]
   `)
@@ -313,9 +465,15 @@ check('Invalid delimiter: expected closing', () =>
       [
         "InvisibleOperator",
         1,
-        ["Error", "unexpected-command", ["LatexString", "\\left"]]
+        {
+          fn: ["Error", "unexpected-command", ["LatexString", "\\left"]];
+              sourceOffsets: [1, 6]
+        }
       ],
-      ["Error", "unexpected-delimiter", ["LatexString", "("]]
+      {
+        fn: ["Error", "unexpected-delimiter", ["LatexString", "("]];
+          sourceOffsets: [6, 7]
+      }
     ]
   `)
 );
@@ -325,7 +483,10 @@ check('Invalid delimiter: expected closing', () =>
     [
       "Sequence",
       1,
-      ["Error", "unexpected-delimiter", ["LatexString", "("]]
+      {
+        fn: ["Error", "unexpected-delimiter", ["LatexString", "("]];
+          sourceOffsets: [1, 2]
+      }
     ]
   `)
 );
@@ -335,7 +496,10 @@ check('Invalid delimiter: expected opening', () =>
     [
       "Sequence",
       1,
-      ["Error", "unexpected-delimiter", ["LatexString", ")"]]
+      {
+        fn: ["Error", "unexpected-delimiter", ["LatexString", ")"]];
+          sourceOffsets: [1, 2]
+      }
     ]
   `)
 );
@@ -347,9 +511,15 @@ check('Invalid delimiter: expected opening', () =>
       [
         "InvisibleOperator",
         1,
-        ["Error", "unexpected-command", ["LatexString", "\\right"]]
+        {
+          fn: ["Error", "unexpected-command", ["LatexString", "\\right"]];
+              sourceOffsets: [1, 7]
+        }
       ],
-      ["Error", "unexpected-delimiter", ["LatexString", ")"]]
+      {
+        fn: ["Error", "unexpected-delimiter", ["LatexString", ")"]];
+          sourceOffsets: [7, 8]
+      }
     ]
   `)
 );
@@ -359,10 +529,16 @@ check('Invalid delimiter', () =>
     [
       "Tuple",
       1,
-      ["Error", "unexpected-command", ["LatexString", "\\left"]],
+      {
+        fn: ["Error", "unexpected-command", ["LatexString", "\\left"]];
+          sourceOffsets: [1, 6]
+      },
       "alpha",
       2,
-      ["Error", "unexpected-command", ["LatexString", "\\right"]],
+      {
+        fn: ["Error", "unexpected-command", ["LatexString", "\\right"]];
+          sourceOffsets: [13, 19]
+      },
       "alpha"
     ]
   `)
@@ -388,7 +564,10 @@ check('Expected closing delimiter', () =>
       [
         "Tuple",
         2,
-        ["Error", "expected-closing-delimiter", ["LatexString", "{2"]]
+        {
+          fn: ["Error", "expected-closing-delimiter", ["LatexString", "{2"]];
+              sourceOffsets: [8, 10]
+        }
       ]
     ]
   `)
@@ -401,7 +580,10 @@ check('Unexpected closing delimiter', () =>
       [
         "Tuple",
         ["Rational", 1, 2],
-        ["Error", "unexpected-closing-delimiter", ["LatexString", "}"]]
+        {
+          fn: ["Error", "unexpected-closing-delimiter", ["LatexString", "}"]];
+              sourceOffsets: [11, 12]
+        }
       ],
       1
     ]
@@ -413,11 +595,14 @@ check('Syntax error: @', () =>
     [
       "Sequence",
       "x",
-      [
-        "Error",
-        ["ErrorCode", "unexpected-token", "@"],
-        ["LatexString", "@"]
-      ]
+      {
+        fn: [
+          "Error",
+          ["ErrorCode", "unexpected-token", "@"],
+          ["LatexString", "@"]
+        ];
+          sourceOffsets: [1, 2]
+      }
     ]
   `)
 );
@@ -429,9 +614,16 @@ check('Trailing bare backslash is tolerated', () =>
 );
 
 check('Syntax error: \\1', () =>
-  expect(engine.parse('x\\1')).toMatchInlineSnapshot(
-    `["Tuple", "x", ["Error", "unexpected-command", ["LatexString", "\\1"]]]`
-  )
+  expect(engine.parse('x\\1')).toMatchInlineSnapshot(`
+    [
+      "Tuple",
+      "x",
+      {
+        fn: ["Error", "unexpected-command", ["LatexString", "\\1"]];
+          sourceOffsets: [1, 3]
+      }
+    ]
+  `)
 );
 
 check('Syntax error: ##', () =>
@@ -439,11 +631,14 @@ check('Syntax error: ##', () =>
     [
       "Sequence",
       "x",
-      [
-        "Error",
-        ["ErrorCode", "unexpected-token", "#"],
-        ["LatexString", "#"]
-      ]
+      {
+        fn: [
+          "Error",
+          ["ErrorCode", "unexpected-token", "#"],
+          ["LatexString", "#"]
+        ];
+          sourceOffsets: [1, 2]
+      }
     ]
   `)
 );
@@ -453,11 +648,14 @@ check('Syntax error: &', () =>
     [
       "Sequence",
       "x",
-      [
-        "Error",
-        ["ErrorCode", "unexpected-token", "&"],
-        ["LatexString", "&"]
-      ]
+      {
+        fn: [
+          "Error",
+          ["ErrorCode", "unexpected-token", "&"],
+          ["LatexString", "&"]
+        ];
+          sourceOffsets: [1, 2]
+      }
     ]
   `)
 );
@@ -482,7 +680,10 @@ check('Syntax error', () =>
       [
         "InvisibleOperator",
         2,
-        ["Error", "expected-closing-delimiter", ["LatexString", "{"]]
+        {
+          fn: ["Error", "expected-closing-delimiter", ["LatexString", "{"]];
+              sourceOffsets: [5, 6]
+        }
       ]
     ]
   `)

--- a/test/compute-engine/latex-syntax/matchfix.test.ts
+++ b/test/compute-engine/latex-syntax/matchfix.test.ts
@@ -177,9 +177,7 @@ describe('MATCHFIX no redundant wrapping', () => {
   });
 
   test('Floor serializes without extra parens', () => {
-    expect(latex(['Floor', 'x'])).toMatchInlineSnapshot(
-      `\\lfloor x\\rfloor`
-    );
+    expect(latex(['Floor', 'x'])).toMatchInlineSnapshot(`\\lfloor x\\rfloor`);
   });
 
   test('Ceil serializes without extra parens', () => {
@@ -189,24 +187,39 @@ describe('MATCHFIX no redundant wrapping', () => {
 
 describe('MATCHFIX invalid', () => {
   test('( // missing closing fence', () =>
-    expect(check('(')).toMatchInlineSnapshot(
-      `invalid   =["Error", "unexpected-delimiter", ["LatexString", "("]]`
-    ));
+    expect(check('(')).toMatchInlineSnapshot(`
+      invalid   ={
+        fn: ["Error", "unexpected-delimiter", ["LatexString", "("]];
+        sourceOffsets: [0, 1]
+      }
+    `));
   test(') // missing opening fence', () => {
-    expect(check(')')).toMatchInlineSnapshot(
-      `invalid   =["Error", "unexpected-delimiter", ["LatexString", ")"]]`
-    );
+    expect(check(')')).toMatchInlineSnapshot(`
+      invalid   ={
+        fn: ["Error", "unexpected-delimiter", ["LatexString", ")"]];
+        sourceOffsets: [0, 1]
+      }
+    `);
   });
 
   test('-( // missing closing fence', () => {
-    expect(engine.parse('-(')).toMatchInlineSnapshot(
-      `["Negate", ["Error", "'missing'", ["LatexString", "-"]]]`
-    );
+    expect(engine.parse('-(')).toMatchInlineSnapshot(`
+      [
+        "Negate",
+        {
+          fn: ["Error", "'missing'", ["LatexString", "-"]];
+            sourceOffsets: [1, 1]
+        }
+      ]
+    `);
   });
 
   test('(3+x // missing closing fence', () => {
-    expect(engine.parse('(3+x')).toMatchInlineSnapshot(
-      `["Error", "unexpected-delimiter", ["LatexString", "("]]`
-    );
+    expect(engine.parse('(3+x')).toMatchInlineSnapshot(`
+      {
+        fn: ["Error", "unexpected-delimiter", ["LatexString", "("]];
+        sourceOffsets: [0, 1]
+      }
+    `);
   });
 });

--- a/test/compute-engine/latex-syntax/operators.test.ts
+++ b/test/compute-engine/latex-syntax/operators.test.ts
@@ -234,15 +234,27 @@ describe('OPERATOR prefix', () => {
 
 describe('OPERATOR infix', () => {
   test('- // Invalid negate', () =>
-    expect(check('-')).toMatchInlineSnapshot(
-      `invalid   =["Negate", ["Error", "'missing'", ["LatexString", "-"]]]`
-    ));
+    expect(check('-')).toMatchInlineSnapshot(`
+      invalid   =[
+        "Negate",
+        {
+          fn: ["Error", "'missing'", ["LatexString", "-"]];
+            sourceOffsets: [1, 1]
+        }
+      ]
+    `));
   test('1- // Invalid subtract', () =>
     expect(check('1-')).toMatchInlineSnapshot(`
       invalid   =[
         "Sequence",
         1,
-        ["Negate", ["Error", "'missing'", ["LatexString", "-"]]]
+        [
+          "Negate",
+          {
+            fn: ["Error", "'missing'", ["LatexString", "-"]];
+                sourceOffsets: [2, 2]
+          }
+        ]
       ]
     `));
 

--- a/test/compute-engine/latex-syntax/parsing.test.ts
+++ b/test/compute-engine/latex-syntax/parsing.test.ts
@@ -16,9 +16,17 @@ describe('ADVANCED PARSING', () => {
   // Empty argument should not be interpreted as space group when argument is
   // expected
   test('\\frac{x}{} y', () =>
-    expect(parse('\\frac{x}{} \\text{ cm}')).toMatchInlineSnapshot(
-      `["Tuple", ["Divide", "x", ["Error", "'missing'"]], "cm"]`
-    ));
+    expect(parse('\\frac{x}{} \\text{ cm}')).toMatchInlineSnapshot(`
+      [
+        "Tuple",
+        [
+          "Divide",
+          "x",
+          {fn: ["Error", "'missing'"]; sourceOffsets: [10, 10]}
+        ],
+        "cm"
+      ]
+    `));
 
   // REVIEW.md C4: parseTextRun joined nested-brace runs with Array.join()
   // (default ',' separator), so `\text{hello {world}}` became 'hello ,world'.
@@ -80,14 +88,24 @@ describe('CUSTOM SYMBOL TYPE CALLBACK', () => {
 
 describe('UNKNOWN COMMANDS', () => {
   test('Parse', () => {
-    expect(parse('\\foo')).toMatchInlineSnapshot(
-      `["Error", "unexpected-command", ["LatexString", "\\foo"]]`
-    );
+    expect(parse('\\foo')).toMatchInlineSnapshot(`
+      {
+        fn: ["Error", "unexpected-command", ["LatexString", "\\foo"]];
+        sourceOffsets: [0, 4]
+      }
+    `);
     expect(parse('x=\\foo+1')).toMatchInlineSnapshot(`
       [
         "Equal",
         "x",
-        ["Add", ["Error", "unexpected-command", ["LatexString", "\\foo"]], 1]
+        [
+          "Add",
+          {
+            fn: ["Error", "unexpected-command", ["LatexString", "\\foo"]];
+                sourceOffsets: [2, 6]
+          },
+          1
+        ]
       ]
     `);
     expect(parse('x=\\foo   {1}  {x+1}+1')).toMatchInlineSnapshot(`
@@ -98,7 +116,10 @@ describe('UNKNOWN COMMANDS', () => {
           "Add",
           [
             "InvisibleOperator",
-            ["Error", "unexpected-command", ["LatexString", "\\foo"]],
+            {
+              fn: ["Error", "unexpected-command", ["LatexString", "\\foo"]];
+                    sourceOffsets: [2, 6]
+            },
             1,
             ["Add", "x", 1]
           ],
@@ -116,7 +137,10 @@ describe('NON-STRICT MODE (Math-ASCII/Typst-like syntax)', () => {
       expect(parse('x^(n+1)')).toMatchInlineSnapshot(`
         [
           "Tuple",
-          ["Error", "'missing'", ["LatexString", "^"]],
+          {
+            fn: ["Error", "'missing'", ["LatexString", "^"]];
+              sourceOffsets: [2, 2]
+          },
           ["Add", "n", 1]
         ]
       `);

--- a/test/compute-engine/latex-syntax/roots.test.ts
+++ b/test/compute-engine/latex-syntax/roots.test.ts
@@ -23,16 +23,19 @@ describe('ROOT FUNCTION', () => {
 describe('ROOT FUNCTION (INVALID FORMS)', () => {
   test('Invalid forms', () => {
     expect(parse('\\sqrt')).toMatchInlineSnapshot(
-      `["Sqrt", ["Error", "'missing'"]]`
+      `["Sqrt", {fn: ["Error", "'missing'"]; sourceOffsets: [5, 5]}]`
     );
     expect(parse('\\sqrt{}')).toMatchInlineSnapshot(
-      `["Sqrt", ["Error", "'missing'"]]`
+      `["Sqrt", {fn: ["Error", "'missing'"]; sourceOffsets: [7, 7]}]`
     );
     expect(parse('\\sqrt{5}[3]')).toMatchInlineSnapshot(`
       [
         "Sequence",
         ["Sqrt", 5],
-        ["Error", "unexpected-operator", ["LatexString", "["]]
+        {
+          fn: ["Error", "unexpected-operator", ["LatexString", "["]];
+            sourceOffsets: [8, 9]
+        }
       ]
     `);
   });

--- a/test/compute-engine/latex-syntax/sequences.test.ts
+++ b/test/compute-engine/latex-syntax/sequences.test.ts
@@ -392,7 +392,10 @@ describe('DELIMITERS PARSING', () => {
         "Delimiter",
         [
           "Sequence",
-          ["Error", "'missing'", ["LatexString", ";"]],
+          {
+            fn: ["Error", "'missing'", ["LatexString", ";"]];
+                sourceOffsets: [1, 1]
+          },
           "Nothing",
           "a",
           "Nothing"

--- a/test/compute-engine/latex-syntax/serialize.test.ts
+++ b/test/compute-engine/latex-syntax/serialize.test.ts
@@ -87,8 +87,14 @@ describe('LATEX SERIALIZING', () => {
     expect(ce.parse('\\foo[0]{1}{2}')).toMatchInlineSnapshot(`
       [
         "Sequence",
-        ["Error", "unexpected-command", ["LatexString", "\\foo"]],
-        ["Error", "unexpected-operator", ["LatexString", "["]]
+        {
+          fn: ["Error", "unexpected-command", ["LatexString", "\\foo"]];
+            sourceOffsets: [0, 4]
+        },
+        {
+          fn: ["Error", "unexpected-operator", ["LatexString", "["]];
+            sourceOffsets: [4, 5]
+        }
       ]
     `);
   });

--- a/test/compute-engine/latex-syntax/stefnotch.test.ts
+++ b/test/compute-engine/latex-syntax/stefnotch.test.ts
@@ -14,8 +14,14 @@ describe('STEFNOTCH #9', () => {
         [
           "Limits",
           "Nothing",
-          ["Error", "expected-closing-delimiter", ["LatexString", "{⬚}"]],
-          ["Error", "expected-closing-delimiter", ["LatexString", "{⬚}"]]
+          {
+            fn: ["Error", "expected-closing-delimiter", ["LatexString", "{⬚}"]];
+                sourceOffsets: [18, 21]
+          },
+          {
+            fn: ["Error", "expected-closing-delimiter", ["LatexString", "{⬚}"]];
+                sourceOffsets: [36, 39]
+          }
         ]
       ]
     `);

--- a/test/compute-engine/latex-syntax/supsub.test.ts
+++ b/test/compute-engine/latex-syntax/supsub.test.ts
@@ -69,13 +69,23 @@ describe('SUPSUB', () => {
     expect(ce.parse('^p_q{x+1}^n_0')).toMatchInlineSnapshot(`
       [
         "Superscript",
-        ["Error", "'missing'", ["LatexString", "^"]],
+        {
+          fn: ["Error", "'missing'", ["LatexString", "^"]];
+            sourceOffsets: [1, 1]
+        },
         ["Error", "'missing'"]
       ]
     `); // @fixme: nope...
-    expect(ce.parse('^{12}_{34}(x+1)^n_0')).toMatchInlineSnapshot(
-      `["Superscript", ["Error", "'missing'", ["LatexString", "^"]], 12]`
-    ); // @fixme: nope...
+    expect(ce.parse('^{12}_{34}(x+1)^n_0')).toMatchInlineSnapshot(`
+      [
+        "Superscript",
+        {
+          fn: ["Error", "'missing'", ["LatexString", "^"]];
+            sourceOffsets: [1, 1]
+        },
+        12
+      ]
+    `); // @fixme: nope...
   });
   test('Accents', () => {
     expect(ce.parse('\\vec{x}')).toMatchInlineSnapshot(`["OverVector", "x"]`);

--- a/test/compute-engine/latex-syntax/symbols.test.ts
+++ b/test/compute-engine/latex-syntax/symbols.test.ts
@@ -418,11 +418,14 @@ describe('SYMBOLS', () => {
   describe('PARSING ERRORS', () => {
     test('Math operators are not valid symbols', () => {
       expect(parse('\\mathrm{=}')).toMatchInlineSnapshot(`
-        [
-          "Error",
-          ["ErrorCode", "invalid-symbol", "invalid-first-char"],
-          ["LatexString", "\\mathrm{=}"]
-        ]
+        {
+          fn: [
+            "Error",
+            ["ErrorCode", "invalid-symbol", "invalid-first-char"],
+            ["LatexString", "\\mathrm{=}"]
+          ];
+          sourceOffsets: [0, 10]
+        }
       `);
     });
     test('Braille via \\char are now encoded as valid symbols', () => {
@@ -434,11 +437,14 @@ describe('SYMBOLS', () => {
     test('Egyptians Hieroglyphs are not valid symbols', () => {
       // Egyptian hieroglyphs are XIDC but rejected by isValidSymbol's script check
       expect(parse('\\mathrm{\\char"13000}')).toMatchInlineSnapshot(`
-        [
-          "Error",
-          ["ErrorCode", "invalid-symbol", "unexpected-script"],
-          ["LatexString", "\\mathrm{\\char"13000}"]
-        ]
+        {
+          fn: [
+            "Error",
+            ["ErrorCode", "invalid-symbol", "unexpected-script"],
+            ["LatexString", "\\mathrm{\\char"13000}"]
+          ];
+          sourceOffsets: [0, 20]
+        }
       `);
     });
 
@@ -449,18 +455,24 @@ describe('SYMBOLS', () => {
 
     test('Symbols should not mix emojis and non-emojis', () => {
       expect(parse('\\mathrm{👨🏻‍🎤DavidBowie}')).toMatchInlineSnapshot(`
-        [
-          "Error",
-          ["ErrorCode", "invalid-symbol", "unexpected-mixed-emoji"],
-          ["LatexString", "\\mathrm{👨🏻‍🎤DavDavidBowie}"]
-        ]
+        {
+          fn: [
+            "Error",
+            ["ErrorCode", "invalid-symbol", "unexpected-mixed-emoji"],
+            ["LatexString", "\\mathrm{👨🏻‍🎤DavDavidBowie}"]
+          ];
+          sourceOffsets: [0, 29]
+        }
       `);
       expect(parse('\\mathrm{DavidBowie👨🏻‍🎤}')).toMatchInlineSnapshot(`
-        [
-          "Error",
-          ["ErrorCode", "invalid-symbol", "unexpected-mixed-emoji"],
-          ["LatexString", "\\mathrm{DavidBowie👨🏻‍🎤}}"]
-        ]
+        {
+          fn: [
+            "Error",
+            ["ErrorCode", "invalid-symbol", "unexpected-mixed-emoji"],
+            ["LatexString", "\\mathrm{DavidBowie👨🏻‍🎤}}"]
+          ];
+          sourceOffsets: [0, 27]
+        }
       `);
     });
   });
@@ -587,9 +599,7 @@ describe('SYMBOLS', () => {
         `x____002012y`
       );
       expect(
-        parse(
-          '\\operatorname{speed\\unicode{"2012}of\\unicode{"2012}sound}'
-        )
+        parse('\\operatorname{speed\\unicode{"2012}of\\unicode{"2012}sound}')
       ).toMatchInlineSnapshot(`speed____002012of____002012sound`);
       // Leading unicode escape
       expect(
@@ -610,7 +620,8 @@ describe('SYMBOLS', () => {
     });
 
     test('Round-trip: parse -> serialize -> parse', () => {
-      const input = '\\operatorname{speed\\unicode{"2012}of\\unicode{"2012}sound}';
+      const input =
+        '\\operatorname{speed\\unicode{"2012}of\\unicode{"2012}sound}';
       const parsed = ce.parse(input);
       // Use .latex property to serialize back
       const serialized = ce.expr(parsed).latex;


### PR DESCRIPTION
closes #311

AI usage disclosure: majority of implementation, human reviewed

## Summary

The LaTeX parser reports parse errors as MathJSON `Error` nodes that say *what* went wrong but not *where* in the input. This PR populates the existing `MathJsonAttributes.sourceOffsets` field on parser-generated `Error` nodes with the character range of the offending LaTeX, so consumers can map a parse error back to its source span — e.g. to highlight the exact invalid token inline in a `MathfieldElement`.

```jsonc
// LatexSyntax().parse('\\foo')
{
  "fn": ["Error", { "str": "unexpected-command" }, ["LatexString", { "str": "\\foo" }]],
  "sourceOffsets": [0, 4]
}
```

> **Live demo:** https://zojize.github.io/compute-engine/ — type an invalid expression and the offending token is colored; empty `\sqrt`/`\frac` slots get a red placeholder box. (Closes #<issue-number>.)

## What's exposed

- **`sourceOffsets` on parser `Error` nodes** — zero-based, **end-exclusive** character offsets into the serialized LaTeX (`tokensToString`). For input that round-trips through the tokenizer unchanged (no comments, Unicode normalization, or macro expansion — i.e. editor-generated LaTeX), they equal offsets into the original input string.
- **Missing-token errors** (empty `\sqrt{}`, empty `\frac{}{}`) use a **zero-width** range at the parser position.
- **`Parser.sourceOffsets(startToken, endToken?)`** — public helper converting a token range to that character range, so custom dictionary entries can attach offsets to errors they raise. `Parser.error()` uses it internally.
- **Boxed path** — offsets propagate through boxing/serialization, so they survive `ce.parse(latex).toMathJson()` (selectable via the `metadata` option, included with `metadata: 'all'`).

## Implementation

Deliberately minimal — **`tokenizer.ts` is not touched.** Offsets are derived from the existing `tokensToString` via prefix length, so no per-token source map is threaded through the tokenizer.

| Area | Change |
|---|---|
| `latex-syntax/parse.ts` | `Parser.sourceOffsets()` (`= latex(0, token).length`); `error()` returns `{ fn, sourceOffsets }` |
| `latex-syntax/dictionary/definitions-arithmetic.ts` | empty `\sqrt{}` / `\frac{}{}` operands emit a positioned `missing` error instead of the position-less `MISSING` sentinel |
| `latex-syntax/types.ts`, `math-json/types.ts` | `Parser.sourceOffsets` signature + documented `sourceOffsets` semantics |
| boxed-expression (`box`, `serialize`, `boxed-function`, `abstract-boxed-expression`) + `math-json/utils.ts`, `types-expression.ts`, `types-kernel-serialization.ts` | propagate `sourceOffsets` through `ce.parse().toMathJson()` |

~150 lines of source + test-snapshot updates.

## ⚠️ Behavior change (please review)

Parser `Error` expressions now use the **object form** `{ fn: ["Error", …], sourceOffsets }` instead of the bare array `["Error", …]` whenever a range is available. Both are valid MathJSON, but a consumer matching `Array.isArray(expr) && expr[0] === "Error"` must also handle `expr.fn?.[0] === "Error"`. This is the bulk of the test-snapshot churn in this PR. If you'd prefer this gated behind a parse option rather than on by default, happy to adjust.

## Limitation (documented on the field)

Offsets are measured on `tokensToString(tokenize(input))`, so they drift from the original string only when that round-trip is lossy — comments, Unicode normalization, or multi-codepoint ZWJ emoji. There the range stays valid and monotonic but isn't byte-aligned to the original. Editor-generated LaTeX never hits those paths, so it's exact in practice. A heavier implementation could thread true source spans through the tokenizer if byte-exact ranges for arbitrary pasted input are ever needed.

## Testing

- `latex-syntax/*` and `incomplete-expressions` suites pass; snapshots updated for the object-form errors. New assertions in `errors.test.ts` cover unknown command (`\foo` → `[0,4]`), nested error through `ce.parse().toMathJson()`, unexpected delimiter, and zero-width missing operands.
- Full suite: 10,496 passing. The only failures are two pre-existing, environment-dependent flakes unrelated to this change — `arithmetic.test.ts` (last-digit machine-float drift) and `compile-performance.test.ts` (a ~1MB memory-threshold assertion).
- `tsc --noEmit` clean.

## Notes

- `src/api.md` is **not** regenerated here — running `typedoc`/`concat-md` locally reformats the whole file (toolchain/version drift, ~3k lines of noise). The API documentation lives in the source doc-comments included in this PR; happy to regenerate `api.md` if you'd like it in the same PR or prefer to do it at release time.
- I can add a `CHANGELOG.md` entry under `## [Unreleased] → ### New Features` if that's the expected flow — let me know.
