### PR TITLE
feat: exact rational DMS parsing and Degrees canonicalization

### DIFF
--- a/src/compute-engine/latex-syntax/dictionary/definitions-arithmetic.ts
+++ b/src/compute-engine/latex-syntax/dictionary/definitions-arithmetic.ts
@@ -14,6 +14,7 @@ import {
   MISSING,
   getSequence,
 } from '../../../math-json/utils.js';
+import { reducedRational } from '../../numerics/rationals.js';
 import {
   Serializer,
   Parser,
@@ -1157,9 +1158,9 @@ function serializePower(
  * Only interprets ' and " as arcmin/arcsec when immediately following
  * a degree symbol, avoiding conflict with Prime (derivative) notation.
  *
- * When all components are numeric, computes decimal degrees and returns
- * Degrees(total). This ensures negation works correctly: -9°30' becomes
- * Negate(Degrees(9.5)) which canonicalizes to -9.5°.
+ * When all components are numeric, returns exact rational degrees
+ * (3600·d + 60·m + s) / 3600 so downstream exact arithmetic works
+ * (e.g. 5°37'30" → π/32).
  */
 function parseDMS(parser: Parser, lhs: MathJsonExpression): MathJsonExpression {
   parser.skipSpace();
@@ -1195,13 +1196,14 @@ function parseDMS(parser: Parser, lhs: MathJsonExpression): MathJsonExpression {
     return ['Degrees', lhs];
   }
 
-  // Compute total decimal degrees when all components are numeric.
+  // Compute exact rational degrees when d and m are numeric.
   // This avoids Negate(Add(Quantity...)) which fails canonicalization.
   const degNum = machineValue(lhs);
   if (degNum !== null && minNum !== null) {
-    let total = degNum + minNum / 60;
-    if (secNum !== null) total += secNum / 3600;
-    return ['Degrees', total];
+    const totalSec = 3600 * degNum + 60 * minNum + (secNum ?? 0);
+    const [numer, denom] = reducedRational([totalSec, 3600]);
+    if (denom === 1) return ['Degrees', numer];
+    return ['Degrees', ['Rational', numer, denom]];
   }
 
   // Fallback for symbolic values: return structured Add form

--- a/src/compute-engine/library/trigonometry.ts
+++ b/src/compute-engine/library/trigonometry.ts
@@ -105,8 +105,10 @@ export const TRIGONOMETRY_LIBRARY: SymbolDefinitions[] = [
         // and corrupted faithful values such as `Degrees(-45.5)`. Angle
         // normalization to a range is a *serialization* concern, controlled by
         // the `angleNormalization` option.)
-        if (Number.isInteger(fArg)) {
-          const fRadians = reducedRational([fArg, 180]);
+        if (arg.isRational === true) {
+          const degNumer = arg.numerator.re;
+          const degDenom = arg.denominator.re;
+          const fRadians = reducedRational([degNumer, degDenom * 180]);
           if (fRadians[0] === 0) return ce.Zero;
           if (fRadians[0] === 1 && fRadians[1] === 1) return ce.Pi;
           if (fRadians[0] === 1) return ce.Pi.div(fRadians[1]);
@@ -134,8 +136,8 @@ export const TRIGONOMETRY_LIBRARY: SymbolDefinitions[] = [
 
         if (Number.isNaN(deg)) return ce._fn('DMS', ops);
 
-        const total = deg + min / 60 + sec / 3600;
-        return ce.function('Degrees', [ce.number(total)]);
+        const totalSec = 3600 * deg + 60 * min + sec;
+        return ce.function('Degrees', [ce.number([totalSec, 3600])]);
       },
       evaluate: (ops, options) => {
         const ce = options.engine;

--- a/test/compute-engine/latex-syntax/parse-dms.test.ts
+++ b/test/compute-engine/latex-syntax/parse-dms.test.ts
@@ -31,30 +31,28 @@ describe('DMS Parsing', () => {
   });
 
   test('parse degrees and arc-minutes', () => {
-    // DMS components are computed to decimal degrees at parse time
-    check("9°30'", ['Degrees', 9.5]);
+    check("9°30'", ['Degrees', ['Rational', 19, 2]]);
   });
 
   test('parse degrees and arc-minutes with \\prime', () => {
-    check('9°30\\prime', ['Degrees', 9.5]);
+    check('9°30\\prime', ['Degrees', ['Rational', 19, 2]]);
   });
 
   test('parse full DMS notation', () => {
-    check('9°30\'15"', ['Degrees', 9.504166666666666]);
+    check('9°30\'15"', ['Degrees', ['Rational', 2281, 240]]);
   });
 
   test('parse DMS with \\doubleprime', () => {
     check('9°30\\prime 15\\doubleprime', [
       'Degrees',
-      9.504166666666666,
+      ['Rational', 2281, 240],
     ]);
   });
 
   test('parse DMS via \\degree trigger', () => {
-    // \\degree should also support DMS
     const ce = new ComputeEngine();
     const expr = ce.parse("9\\degree 30'", { form: 'raw' });
-    expect(expr.json).toEqual(['Degrees', 9.5]);
+    expect(expr.json).toEqual(['Degrees', ['Rational', 19, 2]]);
   });
 });
 
@@ -79,20 +77,19 @@ describe('Prime Disambiguation', () => {
 describe('Negative Angles', () => {
   test('parse negative DMS', () => {
     // -9°30' means -(9°30') = -9.5° (geographic convention)
-    check("-9°30'", ['Negate', ['Degrees', 9.5]]);
+    check("-9°30'", ['Negate', ['Degrees', ['Rational', 19, 2]]]);
   });
 
   test('negative DMS evaluates correctly', () => {
     const ce = new ComputeEngine();
     const expr = ce.parse("-9°30'");
-    // -9.5° = -0.165806... radians
-    expect(expr.N().re).toBeCloseTo(-0.165806, 5);
+    expect(expr.simplify().latex).toBe('\\frac{-19\\pi}{360}');
   });
 
   test('negative full DMS', () => {
     check('-45°30\'15"', [
       'Negate',
-      ['Degrees', 45.50416666666667],
+      ['Degrees', ['Rational', 10921, 240]],
     ]);
   });
 
@@ -100,8 +97,7 @@ describe('Negative Angles', () => {
     const ce = new ComputeEngine();
     const expr = ce.expr(['Negate', ['Quantity', 9.5, 'deg']]);
     const result = expr.evaluate();
-    // Result is Quantity(-9.5, deg) — check the magnitude
-    expect(result.op1.re).toBeCloseTo(-9.5, 10);
+    expect(result.latex).toBe('-9.5\\,\\mathrm{deg}');
   });
 });
 
@@ -109,15 +105,13 @@ describe('DMS Arithmetic', () => {
   test('add two DMS angles', () => {
     const ce = new ComputeEngine();
     const expr = ce.parse("9°0'0\" + 1°0'0\"");
-    // 9° + 1° = 10° ≈ 0.174533 radians
-    expect(expr.N().re).toBeCloseTo(0.174533, 5);
+    expect(expr.simplify().latex).toBe('\\frac{\\pi}{18}');
   });
 
   test('add DMS to simple degree', () => {
     const ce = new ComputeEngine();
     const expr = ce.parse("45°30' + 44°30'");
-    // 45.5° + 44.5° = 90° = π/2 ≈ 1.5708 radians
-    expect(expr.N().re).toBeCloseTo(Math.PI / 2, 5);
+    expect(expr.simplify().latex).toBe('\\frac{\\pi}{2}');
   });
 
   test('parse subtraction in raw form', () => {
@@ -125,22 +119,21 @@ describe('DMS Arithmetic', () => {
     const expr = ce.parse("10°30' - 1°15'", { form: 'raw' });
     expect(expr.json).toEqual([
       'Subtract',
-      ['Degrees', 10.5],
-      ['Degrees', 1.25],
+      ['Degrees', ['Rational', 21, 2]],
+      ['Degrees', ['Rational', 5, 4]],
     ]);
   });
 });
 
 describe('Edge Cases', () => {
   test('decimal arc-minutes', () => {
-    check("9°30.5'", ['Degrees', 9.508333333333333]);
+    check("9°30.5'", ['Degrees', ['Rational', 1141, 120]]);
   });
 
   test('out of range values are mathematically valid', () => {
     const ce = new ComputeEngine();
     const expr = ce.parse("9°90'");
-    // 9° + 90' = 9° + 1.5° = 10.5° ≈ 0.183260 radians
-    expect(expr.N().re).toBeCloseTo(0.183260, 5);
+    expect(expr.simplify().latex).toBe('\\frac{7\\pi}{120}');
   });
 
   test('zero components', () => {
@@ -171,39 +164,34 @@ describe('Edge Cases', () => {
 describe('DMS Function', () => {
   test('DMS(45) is equivalent to Degrees(45)', () => {
     const ce = new ComputeEngine();
-    const dms = ce.expr(['DMS', 45]);
-    const deg = ce.expr(['Degrees', 45]);
-    expect(dms.N().re).toBeCloseTo(deg.N().re!, 10);
+    const dms = ce.expr(['DMS', 45]).simplify();
+    const deg = ce.expr(['Degrees', 45]).simplify();
+    expect(dms.isSame(deg)).toBe(true);
   });
 
-  test('DMS(9, 30) produces 9.5 degrees in radians', () => {
+  test('DMS(9, 30) canonicalizes to radians', () => {
     const ce = new ComputeEngine();
     const expr = ce.expr(['DMS', 9, 30]);
-    // 9.5° = 0.165806... radians
-    expect(expr.N().re).toBeCloseTo(9.5 * Math.PI / 180, 10);
+    expect(expr.simplify().latex).toBe('\\frac{19\\pi}{360}');
   });
 
-  test('DMS(9, 30, 15) produces correct radians', () => {
+  test('DMS(9, 30, 15) canonicalizes to radians', () => {
     const ce = new ComputeEngine();
     const expr = ce.expr(['DMS', 9, 30, 15]);
-    // 9 + 30/60 + 15/3600 = 9.504166... degrees
-    const expectedRad = (9 + 30 / 60 + 15 / 3600) * Math.PI / 180;
-    expect(expr.N().re).toBeCloseTo(expectedRad, 10);
+    expect(expr.simplify().latex).toBe('\\frac{2\\,281\\pi}{43\\,200}');
   });
 
   test('DMS with angularUnit=deg', () => {
     const ce = new ComputeEngine();
     ce.angularUnit = 'deg';
     const expr = ce.expr(['DMS', 9, 30, 15]);
-    // In degree mode, should return decimal degrees directly
-    expect(expr.N().re).toBeCloseTo(9 + 30 / 60 + 15 / 3600, 10);
+    expect(expr.evaluate().latex).toBe('\\frac{2\\,281}{240}');
   });
 
   test('Negate(DMS(9, 30, 15)) works', () => {
     const ce = new ComputeEngine();
     const expr = ce.expr(['Negate', ['DMS', 9, 30, 15]]);
-    const expectedRad = -(9 + 30 / 60 + 15 / 3600) * Math.PI / 180;
-    expect(expr.N().re).toBeCloseTo(expectedRad, 10);
+    expect(expr.simplify().latex).toBe('\\frac{-2\\,281\\pi}{43\\,200}');
   });
 
   test('DMS serialization produces DMS notation', () => {


### PR DESCRIPTION
## Summary

- **parseDMS**: numeric DMS no longer collapses to floating-point degrees; it returns a reduced exact rational `(3600·d + 60·m + s) / 3600` wrapped in `Degrees`.
- **Degrees canonical**: exact conversion to radians now applies to any rational degree (e.g. `19/2°`), not only integers.
- **DMS() canonical**: builds degrees via `ce.number([totalSec, 3600])` instead of a float sum, preserving exactness through the boxing pipeline.
- **Tests**: updated raw-parse expectations to use reduced rationals; evaluation tests assert exact LaTeX via `simplify().latex` instead of floating-point approximations.

## Motivation

DMS angles are naturally exact rationals of a degree: `9°30'` is `19/2°`, not `9.5` as a float. The old pipeline aggregated components with floating-point arithmetic at parse time (`deg + min/60 + sec/3600`), which introduced rounding error before canonicalization.

That mattered downstream: `Degrees` only had an exact rational→radian path for **integer** degrees. A parsed angle like `5°37'30"` became a float, missed the exact branch, and expressions such as converting to radians and simplifying could not reduce to clean fractions (e.g. `π/32`).

This change keeps DMS exact end-to-end - parse as reduced rationals, box `DMS()` the same way, and extend `Degrees` canonicalization to all rational arguments - so degree-to-radian conversion stays symbolically correct.