### PR TITLE
fix: nested sqrt on literals not flattening to a single root

### DIFF
--- a/src/compute-engine/symbolic/simplify-power.ts
+++ b/src/compute-engine/symbolic/simplify-power.ts
@@ -396,9 +396,23 @@ export function simplifyPower(x: Expression): RuleStep | undefined {
     }
 
     // root(sqrt(x), n) -> x^{1/(2n)} (nth root of square root)
+    // Simplify may fold Sqrt(literal) to exact (1)·√a before this rule runs,
+    // so match both the Sqrt node and that numeric square-root form.
+    let innerBase: Expression | null = null;
     if (isFunction(arg, 'Sqrt') && arg.op1) {
-      const innerBase = arg.op1;
-      // root(sqrt(x), n) = x^{1/(2n)}
+      innerBase = arg.op1;
+    } else if (isNumber(arg)) {
+      const nv = arg.numericValue;
+      if (
+        nv instanceof ExactNumericValue &&
+        nv.im === 0 &&
+        nv.radical > 1 &&
+        nv.rational[0] === nv.rational[1]
+      ) {
+        innerBase = ce.number(nv.radical);
+      }
+    }
+    if (innerBase) {
       return {
         value: innerBase.pow(ce.One.div(ce.number(2).mul(rootIndex))),
         because: 'root(sqrt(x), n) -> x^{1/(2n)}',

--- a/test/compute-engine/simplify.test.ts
+++ b/test/compute-engine/simplify.test.ts
@@ -383,6 +383,8 @@ describe('Rules: Roots', () => {
 });
 
 describe('Rules: Nested Roots', () => {
+  test('sqrt(sqrt(sqrt(5))) = 5^{1/8}', () =>
+    checkSimplify('\\sqrt{\\sqrt{\\sqrt{5}}}', '\\sqrt[8]{5}'));
   test('sqrt(sqrt(x)) = x^{1/4}', () =>
     checkSimplify('\\sqrt{\\sqrt{x}}', '\\sqrt[4]{x}'));
   test('cbrt(sqrt(x)) = x^{1/6}', () =>


### PR DESCRIPTION
## Summary

Fix nested sqrt not flattening when the radicand is a numeric literal.

| | Before | After |
|---|---|---|
| Input | $\sqrt{\sqrt{\sqrt{5}}}$ | $\sqrt{\sqrt{\sqrt{5}}}$ |
| `simplify()` | $\sqrt[4]{\sqrt{5}}$ | $\sqrt[8]{5}$ |
| MathJSON | `Root(Sqrt(5), 4)` | `Root(5, 8)` |

Both forms are mathematically equal ($5^{1/8}$), but the before result kept a nested `Sqrt` inside `Root` instead of flattening to a single root.

**Cause:** For literals, simplify folds `Sqrt(5)` into the exact numeric form $(1)\cdot\sqrt{5}$ before the existing `root(sqrt(x), n)` rule runs. That rule only matched `Sqrt` nodes, so it never fired on the folded form.

**Fix:** Extend `root(sqrt(x), n)` in `simplify-power.ts` to also recognize exact numeric square roots $(1)\cdot\sqrt{a}$.

## Test plan

- [x] `sqrt(sqrt(sqrt(5))) = 5^{1/8}` regression test in `simplify.test.ts`
- [x] Existing `Nested Roots` tests still pass