### PR TITLE
fix: align exact-optional internal state declarations

### DIFF
--- a/src/compute-engine/types-engine.ts
+++ b/src/compute-engine/types-engine.ts
@@ -779,18 +779,18 @@ export interface IComputeEngine {
    * by a `withTimeLimit` span.
    * @internal
    */
-  readonly _deadline?: number;
+  readonly _deadline?: number | undefined;
 
   /** The full deadline frame (effective deadline plus attribution).
    * @internal
    */
-  _deadlineFrame?: DeadlineFrame;
+  _deadlineFrame?: DeadlineFrame | undefined;
 
   /** The innermost active `WithRandomSeed` frame (see
    * `withRandomSeedFrame`), or `undefined` when random draws are live.
    * @internal
    */
-  _randomFrame?: RandomSeedFrame;
+  _randomFrame?: RandomSeedFrame | undefined;
 
   /** Time remaining before _deadline
    * @internal


### PR DESCRIPTION
## Summary

- Declare `undefined` explicitly for the three optional `IComputeEngine` members implemented by accessors that can return it.
- Fix `TS2420` for consumers using `exactOptionalPropertyTypes: true` with library checking enabled.

With exact optional-property checking, `property?: T` permits omission but not an explicit `undefined` value. These accessors are always present and return `undefined` when their internal state is inactive, so the interface must include that value.

## Validation

- `npm ci` (production declaration build, NodeNext consumer, Epsil runtime, and Epsil CLI)
- `npm run typecheck`
- Strict consumer checks passed with `skipLibCheck: false` and `exactOptionalPropertyTypes: true` on TypeScript 5.9.3, 6.0.3, and 7.0.2.