### PR TITLE
fix: normalize Log(x, e) to Ln(x) during simplify

### DIFF
--- a/src/compute-engine/boxed-expression/simplify.ts
+++ b/src/compute-engine/boxed-expression/simplify.ts
@@ -801,8 +801,12 @@ function simplifyOperands(
         simplifiedOps.push(full(x, i));
       // Simplify Ln/Log operands within Add/Multiply to enable term cancellation
       // (e.g., ln(x^3) -> 3*ln(x) so that ln(x^3) - 3*ln(x) = 0)
-      // Only simplify Ln (natural log), not Log (which may lose base info)
-      else if (x.operator === 'Ln') simplifiedOps.push(full(x, i));
+      // Log with base e is safe to simplify: log_e(x) -> ln(x)
+      else if (
+        x.operator === 'Ln' ||
+        (isFunction(x, 'Log') && x.op2 && isSymbol(x.op2, 'ExponentialE'))
+      )
+        simplifiedOps.push(full(x, i));
       // Simplify Abs operands to enable cancellation
       // (e.g., |xy| -> |x||y| so that |xy| - |x||y| = 0)
       // Also handle Negate(Abs(...)) which appears in subtraction expressions

--- a/src/compute-engine/symbolic/simplify-log.ts
+++ b/src/compute-engine/symbolic/simplify-log.ts
@@ -7,6 +7,11 @@ import {
 import { toBigint } from '../boxed-expression/numerics.js';
 import { logarithmAtExceptionalPoint } from '../boxed-expression/logarithm.js';
 
+/** Whether `logBase` is Euler's number — `Log(x, e)` is `Ln(x)`. */
+function isNaturalLogBase(base: Expression): boolean {
+  return sym(base) === 'ExponentialE';
+}
+
 /**
  * Logarithm simplification rules consolidated from simplify-rules.ts.
  * Handles ~30 patterns for simplifying Ln and Log expressions.
@@ -240,6 +245,11 @@ function simplifyLogCore(x: Expression): RuleStep | undefined {
       const special = logarithmAtExceptionalPoint(ce, arg, logBase, false);
       if (special !== undefined)
         return { value: special, because: 'log at an exceptional point' };
+    }
+
+    // log_e(x) -> ln(x): base-e logarithm is the natural logarithm
+    if (isNaturalLogBase(logBase)) {
+      return { value: ce._fn('Ln', [arg]), because: 'log_e(x) -> ln(x)' };
     }
 
     // log_c(c) -> 1 (an infinite base was answered above: `∞/∞` is NaN)
@@ -659,27 +669,39 @@ function simplifyLogCore(x: Expression): RuleStep | undefined {
           innerTerm.op1 &&
           innerTerm.op2
         ) {
-          const baseKey = JSON.stringify(innerTerm.op2.json);
-          if (!logTerms.has(baseKey)) {
-            logTerms.set(baseKey, []);
+          if (isNaturalLogBase(innerTerm.op2)) {
+            lnTerms.push({
+              index: i,
+              arg: innerTerm.op1,
+              positive: false,
+            });
+          } else {
+            const baseKey = JSON.stringify(innerTerm.op2.json);
+            if (!logTerms.has(baseKey)) {
+              logTerms.set(baseKey, []);
+            }
+            logTerms.get(baseKey)!.push({
+              index: i,
+              arg: innerTerm.op1,
+              base: innerTerm.op2,
+              positive: false,
+            });
           }
-          logTerms.get(baseKey)!.push({
-            index: i,
-            arg: innerTerm.op1,
-            base: innerTerm.op2,
-            positive: false,
-          });
         }
       }
       // Direct Log term
       else if (isFunction(term, 'Log') && term.op1 && term.op2) {
-        const baseKey = JSON.stringify(term.op2.json);
-        if (!logTerms.has(baseKey)) {
-          logTerms.set(baseKey, []);
+        if (isNaturalLogBase(term.op2)) {
+          lnTerms.push({ index: i, arg: term.op1, positive: true });
+        } else {
+          const baseKey = JSON.stringify(term.op2.json);
+          if (!logTerms.has(baseKey)) {
+            logTerms.set(baseKey, []);
+          }
+          logTerms
+            .get(baseKey)!
+            .push({ index: i, arg: term.op1, base: term.op2, positive: true });
         }
-        logTerms
-          .get(baseKey)!
-          .push({ index: i, arg: term.op1, base: term.op2, positive: true });
       }
     }
 

--- a/test/compute-engine/simplify.test.ts
+++ b/test/compute-engine/simplify.test.ts
@@ -1516,6 +1516,24 @@ describe('LOGARITHM COMBINATION RULES', () => {
     expect(simplify('\\ln(x) + \\ln(y) + z')).toMatchInlineSnapshot(
       `["Add", "z", ["Ln", ["Multiply", "x", "y"]]]`
     ));
+
+  test('log_e(x) -> ln(x)', () =>
+    expect(simplify('\\log_e(x)')).toMatchInlineSnapshot(`["Ln", "x"]`));
+
+  test('log_e(x) + log_e(x) = 2*ln(x)', () =>
+    expect(simplify('\\log_e(x) + \\log_e(x)')).toMatchInlineSnapshot(
+      `["Multiply", 2, ["Ln", "x"]]`
+    ));
+
+  test('log_e(x) + log_e(y) = ln(xy)', () =>
+    expect(simplify('\\log_e(x) + \\log_e(y)')).toMatchInlineSnapshot(
+      `["Ln", ["Multiply", "x", "y"]]`
+    ));
+
+  test('ln(x) + log_e(y) = ln(xy)', () =>
+    expect(simplify('\\ln(x) + \\log_e(y)')).toMatchInlineSnapshot(
+      `["Ln", ["Multiply", "x", "y"]]`
+    ));
 });
 
 describe('INDETERMINATE FORMS', () => {


### PR DESCRIPTION
## Summary

- Add simplify rule `Log(x, ExponentialE)` → `Ln(x)` so `\log_e(x)` is treated like `\ln(x)`
- When combining log terms in `Add`, base-`e` `Log` terms are grouped with `Ln` terms
- Simplify `Log` operands with base `ExponentialE` inside `Add`/`Multiply` (same as `Ln`) so expressions like `\log_e(x) + \log_e(x)` reduce to `2·ln(x)`

## Motivation

`ln(x) + ln(x)` simplified correctly to `2·ln(x)`, but `\log_e(x) + \log_e(x)` did not, because `evaluate()` treats `Log(x, e)` as natural log while `simplify()` kept it as `Log(..., ExponentialE)` and the ln-combination rules only matched `Ln`.

## Test plan

- [x] `log_e(x)` → `Ln(x)`
- [x] `log_e(x) + log_e(x)` → `2·ln(x)`
- [x] `log_e(x) + log_e(y)` → `ln(xy)`
- [x] `ln(x) + log_e(y)` → `ln(xy)`
- [ ] `npm run build`
- [ ] `npx jest test/compute-engine/simplify.test.ts -t "log_e"`